### PR TITLE
[frontend | 고태현 | ADD] - 주변 탐색 및 경로 추천 기능 구현

### DIFF
--- a/Route_Planning/src/components/NearByMap.tsx
+++ b/Route_Planning/src/components/NearByMap.tsx
@@ -1,43 +1,22 @@
 // ═══════════════════════════════════════════════════════════
 // NearByMap — 근처 탐색 지도 컴포넌트 (카카오맵 API 활용)
+// [CHANGED] Tripadvisor API 연동 후 placeList를 prop으로 수신
+//   - 내부 PLACE_LIST mock data 제거
+//   - placeList: Place[] prop 추가
 // ═══════════════════════════════════════════════════════════
 
 import { type FC, useEffect, useRef } from "react";
-import type { Place, PlaceData, Category } from "../types/type";
+import type { Place, Category } from "../types/type";
 import { COLOR_INACTIVE, COLOR_TEXT_MAIN, COLOR_TEXT_SUB } from "../colors";
 import type { KakaoCircle, KakaoMapInstance, KakaoMarker, KakaoOverlay } from "../types/type_kakao";
-import { toPlace } from "../utils/Utils";
-
-// [CONFIG] 반경 옵션
-const RADIUS_OPTION_LIST = [
-  { label: "가까운 곳", meter: 250 },
-  { label: "기본",      meter: 500 },
-  { label: "넓은 곳",   meter: 1000 },
-] as const;
-
-const CATEGORY_ICON: Record<Category, string> = {
-  카페: "☕", 갤러리: "🖼", 공원: "🌿", 명소: "📸", 문화: "🎨", 거리: "🛍",
-};
 
 // [THEME] 지도 핀 파란색
 const COLOR_PIN        = "#3B7DFF";
 const COLOR_PIN_ACTIVE = "#2563EB";
-const COLOR_PIN_RING   = "rgba(59,125,255,0.18)";
 
-const PLACE_LIST: PlaceData[] = [
-  { id:  1, name: "성수연방",          category: "카페",   rating: 4.7, reviews: 2341, district: "성동구", latOffset:  0.002, lngOffset: -0.003 },
-  { id:  2, name: "대림창고",          category: "갤러리", rating: 4.5, reviews: 1823, district: "성동구", latOffset: -0.001, lngOffset:  0.002 },
-  { id:  3, name: "서울숲",            category: "공원",   rating: 4.8, reviews: 5102, district: "성동구", latOffset:  0.004, lngOffset:  0.001 },
-  { id:  4, name: "카페 어니언",       category: "카페",   rating: 4.6, reviews: 3214, district: "성동구", latOffset: -0.002, lngOffset:  0.003 },
-  { id:  5, name: "하이브 사옥",       category: "명소",   rating: 4.9, reviews: 8821, district: "용산구", latOffset:  0.006, lngOffset: -0.004 },
-  { id:  6, name: "경리단길",          category: "거리",   rating: 4.3, reviews: 2109, district: "용산구", latOffset: -0.005, lngOffset:  0.005 },
-  { id:  7, name: "SM 엔터테인먼트",   category: "명소",   rating: 4.7, reviews: 6432, district: "강남구", latOffset:  0.008, lngOffset:  0.006 },
-  { id:  8, name: "별마당도서관",      category: "문화",   rating: 4.6, reviews: 4521, district: "강남구", latOffset: -0.007, lngOffset: -0.002 },
-  { id:  9, name: "광화문 광장",       category: "명소",   rating: 4.7, reviews: 6230, district: "종로구", latOffset:  0.003, lngOffset: -0.006 },
-  { id: 10, name: "홍대 걷고싶은거리", category: "거리",   rating: 4.5, reviews: 8320, district: "마포구", latOffset: -0.004, lngOffset:  0.007 },
-  { id: 11, name: "연남동 카페거리",   category: "카페",   rating: 4.5, reviews: 3412, district: "마포구", latOffset:  0.001, lngOffset: -0.005 },
-  { id: 12, name: "남산타워",          category: "명소",   rating: 4.6, reviews: 9103, district: "용산구", latOffset:  0.005, lngOffset:  0.004 },
-];
+const CATEGORY_ICON: Record<Category, string> = {
+  카페: "☕", 갤러리: "🖼", 공원: "🌿", 명소: "📸", 문화: "🎨", 거리: "🛍",
+};
 
 interface NearbyMapProps {
   userLat:           number;
@@ -51,18 +30,19 @@ interface NearbyMapProps {
   onSelectRadius:    (idx: number) => void;
   kakaoMapRef:       React.MutableRefObject<KakaoMapInstance | null>;
   isMapReady:        boolean;
+  // [CHANGED] Tripadvisor API에서 받아온 장소 목록
+  placeList:         Place[];
 }
 
 const NearbyMap: FC<NearbyMapProps> = ({
-  userLat, userLng, isLocating, locLabel,
+  userLat, userLng, locLabel,
   radiusMeter, selectedPlace, onSelectPlace,
   kakaoMapRef, isMapReady,
+  placeList,   // [CHANGED] 외부에서 주입
 }) => {
   const circleRef      = useRef<KakaoCircle | null>(null);
   const overlayListRef = useRef<KakaoOverlay[]>([]);
   const markerListRef  = useRef<KakaoMarker[]>([]);
-
-  // [NOTE] 현위치 마커는 RouteScreen에서 관리 (탭 무관하게 항상 표시)
 
   // [SYNC] 반경 원 업데이트
   useEffect(() => {
@@ -83,6 +63,8 @@ const NearbyMap: FC<NearbyMapProps> = ({
   }, [isMapReady, radiusMeter, userLat, userLng, kakaoMapRef]);
 
   // [SYNC] 장소 마커 업데이트
+  // [CHANGED] PLACE_LIST 대신 placeList prop 사용
+  //           place.lat / place.lng / place.distance가 이미 계산된 상태로 들어옴
   useEffect(() => {
     if (!isMapReady || !kakaoMapRef.current) return;
     overlayListRef.current.forEach(o => o.setMap(null));
@@ -92,7 +74,8 @@ const NearbyMap: FC<NearbyMapProps> = ({
 
     const hasSelection = selectedPlace !== null;
 
-    PLACE_LIST.map(p => toPlace(p, userLat, userLng)).forEach(place => {
+    placeList.forEach(place => {
+      // 반경 내 여부
       const isActive       = place.distance <= radiusMeter;
       const isSelected     = selectedPlace?.id === place.id;
       const isDeemphasized = hasSelection && !isSelected && isActive;
@@ -102,12 +85,14 @@ const NearbyMap: FC<NearbyMapProps> = ({
       const opacity  = isActive ? (isDeemphasized ? 0.4 : 1) : 0.3;
       const pos      = new window.kakao.maps.LatLng(place.lat, place.lng);
 
+      const categoryIcon = CATEGORY_ICON[place.category] ?? "📍";
+
       const el = document.createElement("div");
       el.style.cssText = `display:flex;flex-direction:column;align-items:center;cursor:${isActive ? "pointer" : "default"};opacity:${opacity};filter:${isActive ? "none" : "grayscale(100%)"};transition:all 0.25s;`;
       el.innerHTML = `
         ${isSelected && isActive ? `
           <div style="background:#fff;border-radius:10px;padding:5px 10px;margin-bottom:5px;white-space:nowrap;box-shadow:0 4px 16px rgba(0,0,0,0.14);font-size:12px;font-weight:700;color:${COLOR_TEXT_MAIN};border:2px solid ${COLOR_PIN};position:relative;font-family:'Noto Sans KR',sans-serif;">
-            ${place.name} ⭐${place.rating}
+            ${categoryIcon} ${place.name} ⭐${place.rating}
             <div style="position:absolute;bottom:-7px;left:50%;transform:translateX(-50%);width:0;height:0;border-left:6px solid transparent;border-right:6px solid transparent;border-top:7px solid ${COLOR_PIN};"></div>
           </div>` : ""}
         <div style="width:${size}px;height:${size}px;border-radius:50% 50% 50% 0;transform:rotate(-45deg);background:${pinColor};border:2.5px solid #fff;box-shadow:${isSelected ? "0 4px 14px rgba(59,125,255,0.45)" : "0 2px 8px rgba(0,0,0,0.18)"};transition:all 0.25s;"></div>
@@ -120,7 +105,10 @@ const NearbyMap: FC<NearbyMapProps> = ({
       overlayListRef.current.push(overlay);
 
       if (isActive) {
-        const invisImg    = new window.kakao.maps.MarkerImage("data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7", new window.kakao.maps.Size(44, 54));
+        const invisImg    = new window.kakao.maps.MarkerImage(
+          "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
+          new window.kakao.maps.Size(44, 54),
+        );
         const invisMarker = new window.kakao.maps.Marker({ position: pos, image: invisImg });
         invisMarker.setMap(kakaoMapRef.current!);
         markerListRef.current.push(invisMarker);
@@ -129,15 +117,16 @@ const NearbyMap: FC<NearbyMapProps> = ({
         });
       }
     });
+
     return () => {
       overlayListRef.current.forEach(o => o.setMap(null));
       markerListRef.current.forEach(m => m.setMap(null));
       overlayListRef.current = [];
       markerListRef.current  = [];
     };
-  }, [isMapReady, radiusMeter, selectedPlace, userLat, userLng, onSelectPlace, kakaoMapRef]);
+  // [CHANGED] placeList도 의존성에 포함
+  }, [isMapReady, radiusMeter, selectedPlace, userLat, userLng, onSelectPlace, kakaoMapRef, placeList]);
 
-  // [NOTE] 반경 버튼은 바텀 시트 패널로 이동
   return (
     <div style={{
       position: "absolute", top: 80, left: "50%", transform: "translateX(-50%)",

--- a/Route_Planning/src/components/RecommendPanel.tsx
+++ b/Route_Planning/src/components/RecommendPanel.tsx
@@ -1,0 +1,420 @@
+// ═══════════════════════════════════════════════════════════
+// RecommendPanel — 추천 경로 패널
+// [CHANGED] 경로 탐색 기능 통합
+//   - 추천 장소들을 출발지~경유지~도착지로 설정
+//   - 카카오 Directions API로 실제 경로 폴리라인 지도에 표시
+//   - 거리/시간/요금/교통혼잡도 결과 카드 표시
+// ═══════════════════════════════════════════════════════════
+
+import { type FC, useState, useCallback } from "react";
+import type { Category, DirectionsResponse, RouteResult } from "../types/type";
+import type { RecommendedRoute, RecommendedPlace } from "../hooks/Userecommendedroute";
+import type { KakaoMapInstance, KakaoOverlay, KakaoPolyline } from "../types/type_kakao";
+import {
+  COLOR_PRIMARY, COLOR_PRIMARY_LIGHT, COLOR_SURFACE,
+  COLOR_BORDER, COLOR_BG, COLOR_TEXT_MAIN, COLOR_TEXT_SUB,
+  COLOR_INACTIVE, COLOR_ORIGIN, COLOR_DEST, TRAFFIC_COLOR_MAP,
+} from "../colors";
+import { formatDistance, formatDuration } from "../utils/Utils";
+
+// ── [CONFIG] ──────────────────────────────────────────────
+
+const CATEGORY_ICON: Record<Category, string> = {
+  카페: "☕", 갤러리: "🖼", 공원: "🌿", 명소: "📸", 문화: "🎨", 거리: "🛍",
+};
+
+const COLOR_CATEGORY: Record<Category, string> = {
+  카페: "#b45309", 갤러리: "#7c3aed", 공원: "#16a34a",
+  명소: "#1d4ed8",  문화: "#0e7490",  거리: "#be185d",
+};
+
+// ── [API] 추천 경유지 포함 실제 경로 조회 ─────────────────
+
+const fetchRecommendRoute = async (
+  places: RecommendedPlace[],
+  userLat: number,
+  userLng: number,
+): Promise<RouteResult> => {
+  if (places.length === 0) throw new Error("경유지가 없어요");
+
+  const origin      = { lat: userLat, lng: userLng };
+  const destination = places[places.length - 1];
+  const waypoints   = places
+    .slice(0, -1)
+    .map(p => `${p.lng},${p.lat}`)
+    .join("|");
+
+  const params = new URLSearchParams({
+    origin:      `${origin.lng},${origin.lat}`,
+    destination: `${destination.lng},${destination.lat}`,
+    priority:    "RECOMMEND",
+    car_fuel:    "GASOLINE",
+    car_hipass:  "false",
+    alternatives:"false",
+    road_details:"false",
+    ...(waypoints ? { waypoints } : {}),
+  });
+
+  const res = await fetch(`${import.meta.env.VITE_KAKAO_DIRECTIONS_URL}?${params}`, {
+    headers: { Authorization: `KakaoAK ${import.meta.env.VITE_KAKAO_REST_API_KEY}` },
+  });
+
+  if (!res.ok) throw new Error(`경로 API 오류: ${res.status}`);
+
+  const data: DirectionsResponse = await res.json();
+  const route = data.routes?.[0];
+  if (!route || route.result_code !== 0) {
+    throw new Error(route?.result_msg ?? "경로를 찾을 수 없어요");
+  }
+
+  const roads = route.sections.flatMap(s => s.roads);
+  return {
+    distanceMeter: route.summary.distance,
+    durationSec:   route.summary.duration,
+    taxiFare:      route.summary.fare.taxi,
+    tollFare:      route.summary.fare.toll,
+    roads,
+  };
+};
+
+// ── [지도] 폴리라인 렌더링 ────────────────────────────────
+
+const drawRouteOnMap = (
+  result:      RouteResult,
+  kakaoMapRef: React.MutableRefObject<KakaoMapInstance | null>,
+  polylineListRef: React.MutableRefObject<KakaoPolyline[]>,
+  overlayListRef:  React.MutableRefObject<KakaoOverlay[]>,
+  places:      RecommendedPlace[],
+  userLat:     number,
+  userLng:     number,
+) => {
+  if (!kakaoMapRef.current) return;
+
+  // 기존 레이어 정리
+  polylineListRef.current.forEach(p => p.setMap(null));
+  overlayListRef.current.forEach(o => o.setMap(null));
+  polylineListRef.current = [];
+  overlayListRef.current  = [];
+
+  // 폴리라인 그리기
+  result.roads.forEach(road => {
+    const path: object[] = [];
+    for (let i = 0; i < road.vertexes.length - 1; i += 2) {
+      path.push(new window.kakao.maps.LatLng(road.vertexes[i + 1], road.vertexes[i]));
+    }
+    if (path.length < 2) return;
+    const polyline = new window.kakao.maps.Polyline({
+      map:           kakaoMapRef.current!,
+      path,
+      strokeWeight:  6,
+      strokeColor:   TRAFFIC_COLOR_MAP[road.traffic_state] ?? TRAFFIC_COLOR_MAP[0],
+      strokeOpacity: 0.9,
+      strokeStyle:   "solid",
+    });
+    polylineListRef.current.push(polyline);
+  });
+
+  // 출발지 마커
+  const makePin = (lat: number, lng: number, color: string, emoji: string, label: string) => {
+    const el = document.createElement("div");
+    el.style.cssText = "display:flex;flex-direction:column;align-items:center;";
+    el.innerHTML = `
+      <div style="background:#fff;border-radius:8px;padding:3px 8px;margin-bottom:4px;white-space:nowrap;box-shadow:0 2px 8px rgba(0,0,0,0.12);font-size:11px;font-weight:700;color:#1a1a1a;border:1.5px solid ${color};font-family:'Noto Sans KR',sans-serif;">${label}</div>
+      <div style="width:28px;height:28px;border-radius:50% 50% 50% 0;transform:rotate(-45deg);background:${color};border:2.5px solid #fff;box-shadow:0 2px 8px rgba(0,0,0,0.2);display:flex;align-items:center;justify-content:center;">
+        <span style="transform:rotate(45deg);font-size:12px;">${emoji}</span>
+      </div>`;
+    const overlay = new window.kakao.maps.CustomOverlay({
+      map: kakaoMapRef.current!, content: el, yAnchor: 1.1, zIndex: 15,
+      position: new window.kakao.maps.LatLng(lat, lng),
+    });
+    overlayListRef.current.push(overlay);
+  };
+
+  makePin(userLat, userLng, COLOR_ORIGIN, "🟢", "출발");
+  places.forEach((p, i) => {
+    const isLast = i === places.length - 1;
+    makePin(p.lat, p.lng, isLast ? COLOR_DEST : COLOR_PRIMARY,
+      isLast ? "🔴" : `${i + 1}`,
+      isLast ? p.name : `${i + 1}. ${p.name}`);
+  });
+
+  // 지도 범위 자동 맞춤
+  const bounds = new window.kakao.maps.LatLngBounds();
+  result.roads.forEach(road => {
+    for (let i = 0; i < road.vertexes.length - 1; i += 2) {
+      bounds.extend(new window.kakao.maps.LatLng(road.vertexes[i + 1], road.vertexes[i]));
+    }
+  });
+  kakaoMapRef.current!.setBounds(bounds, 60, 60, 60, 60);
+};
+
+// ── [COMPONENT] 경유지 카드 ───────────────────────────────
+
+const PlaceStopCard: FC<{
+  place:   RecommendedPlace;
+  index:   number;
+  isLast:  boolean;
+  onClick: (place: RecommendedPlace) => void;
+}> = ({ place, index, isLast, onClick }) => (
+  <div style={{ display: "flex", gap: 12 }}>
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", flexShrink: 0 }}>
+      <div style={{ width: 28, height: 28, borderRadius: "50%", background: COLOR_PRIMARY, color: "#fff", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 12, fontWeight: 800 }}>
+        {index + 1}
+      </div>
+      {!isLast && <div style={{ width: 2, flex: 1, minHeight: 20, background: `${COLOR_PRIMARY}30`, marginTop: 4 }} />}
+    </div>
+    <div onClick={() => onClick(place)} style={{ flex: 1, marginBottom: isLast ? 0 : 12, background: COLOR_SURFACE, borderRadius: 12, border: `1.5px solid ${COLOR_BORDER}`, padding: "10px 12px", cursor: "pointer", boxShadow: "0 1px 4px rgba(0,0,0,0.06)", transition: "all 0.18s" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 5 }}>
+        <span style={{ fontSize: 10, fontWeight: 700, padding: "2px 7px", borderRadius: 6, background: `${COLOR_CATEGORY[place.category]}18`, color: COLOR_CATEGORY[place.category] }}>
+          {CATEGORY_ICON[place.category]} {place.category}
+        </span>
+        <span style={{ fontSize: 13, fontWeight: 700, color: COLOR_TEXT_MAIN, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{place.name}</span>
+      </div>
+      <div style={{ display: "flex", gap: 8, fontSize: 11, color: COLOR_TEXT_SUB, alignItems: "center" }}>
+        {place.rating > 0 && (
+          <>
+            <span style={{ color: "#f59e0b", fontWeight: 700 }}>★ {place.rating.toFixed(1)}</span>
+            {place.reviews > 0 && <span>리뷰 {place.reviews.toLocaleString()}</span>}
+            <span>·</span>
+          </>
+        )}
+        <span style={{ color: COLOR_PRIMARY, fontWeight: 600 }}>{place.distance}m</span>
+        {place.district && <><span>·</span><span>{place.district}</span></>}
+      </div>
+      {place.score > 0 && (
+        <div style={{ marginTop: 8 }}>
+          <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 3 }}>
+            <span style={{ fontSize: 9, color: COLOR_TEXT_SUB }}>추천 점수</span>
+            <span style={{ fontSize: 9, fontWeight: 700, color: COLOR_PRIMARY }}>{place.score.toFixed(1)}점</span>
+          </div>
+          <div style={{ height: 3, background: COLOR_BG, borderRadius: 2, overflow: "hidden" }}>
+            <div style={{ height: "100%", borderRadius: 2, background: `linear-gradient(90deg, ${COLOR_PRIMARY}, #60a5fa)`, width: `${Math.min(place.score / 8 * 100, 100)}%`, transition: "width 0.6s ease" }} />
+          </div>
+        </div>
+      )}
+    </div>
+  </div>
+);
+
+// ── [COMPONENT] 경로 결과 카드 (RoutePanel과 동일한 UI) ────
+
+const RouteResultCard: FC<{
+  result:      RouteResult;
+  places:      RecommendedPlace[];
+  userLat:     number;
+  userLng:     number;
+}> = ({ result, places, userLat, userLng }) => (
+  <div style={{ background: COLOR_SURFACE, borderRadius: 14, border: `1.5px solid ${COLOR_PRIMARY}`, overflow: "hidden", marginTop: 12 }}>
+    {/* 요약 헤더 */}
+    <div style={{ background: COLOR_PRIMARY_LIGHT, padding: "14px 16px", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+      <div>
+        <div style={{ fontSize: 22, fontWeight: 900, color: COLOR_PRIMARY }}>{formatDuration(result.durationSec)}</div>
+        <div style={{ fontSize: 12, color: COLOR_TEXT_SUB, marginTop: 2 }}>총 {formatDistance(result.distanceMeter)}</div>
+      </div>
+      <div style={{ textAlign: "right" }}>
+        {result.taxiFare > 0 && <div style={{ fontSize: 13, fontWeight: 700, color: COLOR_TEXT_MAIN }}>🚕 {result.taxiFare.toLocaleString()}원</div>}
+        {result.tollFare > 0 && <div style={{ fontSize: 11, color: COLOR_TEXT_SUB, marginTop: 2 }}>통행료 {result.tollFare.toLocaleString()}원</div>}
+      </div>
+    </div>
+
+    {/* 경유 목록 */}
+    <div style={{ padding: "12px 16px", display: "flex", flexDirection: "column", gap: 6 }}>
+      {/* 출발 */}
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <div style={{ width: 8, height: 8, borderRadius: "50%", background: COLOR_ORIGIN, flexShrink: 0 }} />
+        <div style={{ fontSize: 12, color: COLOR_TEXT_MAIN }}>현재 위치</div>
+      </div>
+      {places.map((p, i) => (
+        <div key={p.id}>
+          <div style={{ width: 2, height: 10, background: COLOR_BORDER, marginLeft: 3, marginBottom: 6 }} />
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <div style={{ width: 8, height: 8, borderRadius: i === places.length - 1 ? 2 : "50%", background: i === places.length - 1 ? COLOR_DEST : COLOR_PRIMARY, flexShrink: 0 }} />
+            <div style={{ fontSize: 12, color: COLOR_TEXT_MAIN, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{p.name}</div>
+          </div>
+        </div>
+      ))}
+    </div>
+
+    {/* 교통 혼잡도 범례 */}
+    <div style={{ padding: "8px 16px 14px", display: "flex", gap: 12, flexWrap: "wrap" }}>
+      {([0, 1, 2, 3] as const).map(state => {
+        const labels = ["원활", "서행", "정체", "매우정체"];
+        return (
+          <div key={state} style={{ display: "flex", alignItems: "center", gap: 4 }}>
+            <div style={{ width: 20, height: 4, borderRadius: 2, background: TRAFFIC_COLOR_MAP[state] }} />
+            <span style={{ fontSize: 10, color: COLOR_TEXT_SUB }}>{labels[state]}</span>
+          </div>
+        );
+      })}
+    </div>
+  </div>
+);
+
+// ── [COMPONENT] 메인 패널 ─────────────────────────────────
+
+interface RecommendPanelProps {
+  route:        RecommendedRoute | null;
+  isLoading:    boolean;
+  error:        string | null;
+  onRefetch:    () => void;
+  onSelectPlace:(place: RecommendedPlace) => void;
+  // 경로 탐색 기능용
+  kakaoMapRef:     React.MutableRefObject<KakaoMapInstance | null>;
+  polylineListRef: React.MutableRefObject<KakaoPolyline[]>;
+  overlayListRef:  React.MutableRefObject<KakaoOverlay[]>;
+  userLat:      number;
+  userLng:      number;
+}
+
+const RecommendPanel: FC<RecommendPanelProps> = ({
+  route, isLoading, error, onRefetch, onSelectPlace,
+  kakaoMapRef, polylineListRef, overlayListRef,
+  userLat, userLng,
+}) => {
+  const [routeResult,    setRouteResult]    = useState<RouteResult | null>(null);
+  const [routeLoading,   setRouteLoading]   = useState<boolean>(false);
+  const [routeError,     setRouteError]     = useState<string | null>(null);
+  const [routeDrawn,     setRouteDrawn]     = useState<boolean>(false);
+
+  // 경로 탐색 실행
+  const handleDrawRoute = useCallback(async () => {
+    if (!route) return;
+    setRouteLoading(true);
+    setRouteError(null);
+    setRouteResult(null);
+    setRouteDrawn(false);
+    try {
+      const result = await fetchRecommendRoute(route.places, userLat, userLng);
+      setRouteResult(result);
+      drawRouteOnMap(result, kakaoMapRef, polylineListRef, overlayListRef, route.places, userLat, userLng);
+      setRouteDrawn(true);
+    } catch (e) {
+      setRouteError((e as Error).message);
+    } finally {
+      setRouteLoading(false);
+    }
+  }, [route, userLat, userLng, kakaoMapRef, polylineListRef, overlayListRef]);
+
+  // 경로 초기화
+  const handleClearRoute = useCallback(() => {
+    polylineListRef.current.forEach(p => p.setMap(null));
+    overlayListRef.current.forEach(o => o.setMap(null));
+    polylineListRef.current = [];
+    overlayListRef.current  = [];
+    setRouteResult(null);
+    setRouteDrawn(false);
+    setRouteError(null);
+  }, [polylineListRef, overlayListRef]);
+
+  // 재추천 시 경로도 초기화
+  const handleRefetch = useCallback(() => {
+    handleClearRoute();
+    onRefetch();
+  }, [handleClearRoute, onRefetch]);
+
+  // ── 로딩
+  if (isLoading) return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 14, padding: "48px 24px" }}>
+      <div style={{ position: "relative", width: 48, height: 48 }}>
+        <div style={{ position: "absolute", inset: 0, border: `3px solid ${COLOR_PRIMARY}20`, borderRadius: "50%" }} />
+        <div style={{ position: "absolute", inset: 0, border: `3px solid ${COLOR_PRIMARY}`, borderTopColor: "transparent", borderRadius: "50%", animation: "spin 0.8s linear infinite" }} />
+      </div>
+      <div style={{ textAlign: "center" }}>
+        <div style={{ fontSize: 14, fontWeight: 700, color: COLOR_TEXT_MAIN, marginBottom: 4 }}>최적 경로 분석 중</div>
+        <div style={{ fontSize: 12, color: COLOR_TEXT_SUB }}>주변 장소 평점을 수집하고 있어요</div>
+      </div>
+      <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+    </div>
+  );
+
+  // ── 에러
+  if (error) return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 12, padding: "48px 24px" }}>
+      <span style={{ fontSize: 36 }}>⚠️</span>
+      <span style={{ fontSize: 13, color: "#e53e3e", textAlign: "center" }}>{error}</span>
+      <button onClick={handleRefetch} style={{ padding: "9px 20px", borderRadius: 10, border: `1.5px solid ${COLOR_PRIMARY}`, background: "transparent", color: COLOR_PRIMARY, fontSize: 13, fontWeight: 700, cursor: "pointer", fontFamily: "'Noto Sans KR', sans-serif" }}>다시 시도</button>
+    </div>
+  );
+
+  if (!route) return (
+    <div style={{ textAlign: "center", color: COLOR_INACTIVE, fontSize: 13, padding: "48px 24px" }}>
+      추천 경로를 불러오는 중이에요
+    </div>
+  );
+
+  return (
+    <div style={{ padding: "16px 16px 32px" }}>
+
+      {/* 요약 헤더 */}
+      <div style={{ background: COLOR_PRIMARY_LIGHT, borderRadius: 14, padding: "14px 16px", marginBottom: 16, border: `1.5px solid ${COLOR_PRIMARY}30`, display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <div>
+          <div style={{ fontSize: 11, color: COLOR_TEXT_SUB, fontWeight: 600, marginBottom: 3 }}>🗺 AI 추천 코스 · {route.places.length}곳</div>
+          <div style={{ fontSize: 22, fontWeight: 900, color: COLOR_PRIMARY }}>
+            {route.totalDuration > 0 ? formatDuration(route.totalDuration) : `${route.places.length}개 장소`}
+          </div>
+          {route.totalDistance > 0 && (
+            <div style={{ fontSize: 12, color: COLOR_TEXT_SUB, marginTop: 2 }}>총 {formatDistance(route.totalDistance)}</div>
+          )}
+        </div>
+        <button onClick={handleRefetch} style={{ background: "none", border: `1px solid ${COLOR_PRIMARY}40`, borderRadius: 8, padding: "6px 10px", cursor: "pointer", fontSize: 13, color: COLOR_PRIMARY, fontFamily: "'Noto Sans KR', sans-serif" }}>
+          🔄 재추천
+        </button>
+      </div>
+
+      {/* 추천 기준 배지 */}
+      <div style={{ display: "flex", gap: 6, marginBottom: 16, flexWrap: "wrap" }}>
+        {["⭐ 평점 우선", "📍 거리 고려", "🎨 카테고리 다양성"].map(label => (
+          <span key={label} style={{ fontSize: 10, fontWeight: 600, padding: "3px 8px", borderRadius: 6, background: COLOR_BG, color: COLOR_TEXT_SUB, border: `1px solid ${COLOR_BORDER}` }}>{label}</span>
+        ))}
+      </div>
+
+      {/* 경유지 목록 */}
+      <div style={{ marginBottom: 16 }}>
+        {route.places.map((place, i) => (
+          <PlaceStopCard key={place.id} place={place} index={i} isLast={i === route.places.length - 1} onClick={onSelectPlace} />
+        ))}
+      </div>
+
+      {/* 경로 탐색 버튼 */}
+      {!routeDrawn && (
+        <button
+          onClick={handleDrawRoute}
+          disabled={routeLoading}
+          style={{ width: "100%", padding: "12px 0", borderRadius: 12, border: "none", background: routeLoading ? COLOR_INACTIVE : COLOR_PRIMARY, color: "#fff", fontSize: 14, fontWeight: 700, cursor: routeLoading ? "default" : "pointer", fontFamily: "'Noto Sans KR', sans-serif", transition: "all 0.18s" }}
+        >
+          {routeLoading ? "경로 계산 중..." : "🗺 이 경로로 길 찾기"}
+        </button>
+      )}
+
+      {/* 경로 초기화 버튼 */}
+      {routeDrawn && (
+        <button
+          onClick={handleClearRoute}
+          style={{ width: "100%", padding: "12px 0", borderRadius: 12, border: `1.5px solid ${COLOR_BORDER}`, background: COLOR_SURFACE, color: COLOR_TEXT_SUB, fontSize: 14, fontWeight: 700, cursor: "pointer", fontFamily: "'Noto Sans KR', sans-serif" }}
+        >
+          ✕ 경로 지우기
+        </button>
+      )}
+
+      {/* 경로 에러 */}
+      {routeError && (
+        <div style={{ marginTop: 8, fontSize: 12, color: "#e53e3e", fontWeight: 600, textAlign: "center" }}>{routeError}</div>
+      )}
+
+      {/* 경로 결과 카드 */}
+      {routeResult && (
+        <RouteResultCard result={routeResult} places={route.places} userLat={userLat} userLng={userLng} />
+      )}
+
+      {/* 안내 문구 */}
+      <div style={{ marginTop: 16, padding: "10px 14px", background: COLOR_BG, borderRadius: 10, border: `1px solid ${COLOR_BORDER}` }}>
+        <div style={{ fontSize: 11, color: COLOR_TEXT_SUB, lineHeight: 1.6 }}>
+          💡 장소를 탭하면 지도에서 위치를 확인할 수 있어요.<br />
+          평점은 Tripadvisor 기준이며, 매칭되지 않은 장소는 점수 없이 표시돼요.
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RecommendPanel;

--- a/Route_Planning/src/components/RoutePanel.tsx
+++ b/Route_Planning/src/components/RoutePanel.tsx
@@ -1,238 +1,714 @@
 // ═══════════════════════════════════════════════════════════
-// RoutePanel — 출발지/도착지 입력 + 경로 결과 카드
+// RoutePanel — 경로 탐색 + 추천 경로 통합 패널
+//
+// [구조]
+//   상단 탭: "직접 입력" | "추천 경로"
+//
+//   직접 입력 탭:
+//     - 출발지/도착지 입력 + 경유지 자동 추천
+//     - 경로 탐색 → 지도 폴리라인 + 결과 카드
+//
+//   추천 경로 탭:
+//     - 현위치 기반 후보 경로 3개 카드
+//     - 카드 선택 → 지도에 해당 경로 표시
+//     - 선택된 경로 상세 결과 카드
 // ═══════════════════════════════════════════════════════════
 
 import { type FC, useState, useCallback } from "react";
-import type { RouteState, RoutePoint, RouteResult, DirectionsResponse } from "../types/type";
-import { COLOR_BORDER, 
-        COLOR_DANGER, 
-        COLOR_INACTIVE, 
-        COLOR_PRIMARY, 
-        COLOR_PRIMARY_LIGHT, 
-        COLOR_SURFACE, 
-        COLOR_TEXT_MAIN, 
-        COLOR_TEXT_SUB, 
-        COLOR_ORIGIN, 
-        COLOR_DEST,
-        TRAFFIC_COLOR_MAP } from "../colors";
+import type { RouteState, RoutePoint, RouteResult, DirectionsResponse, Category } from "../types/type";
+import type { KakaoMapInstance, KakaoOverlay, KakaoPolyline } from "../types/type_kakao";
+import {
+  COLOR_BORDER, COLOR_DANGER, COLOR_INACTIVE, COLOR_PRIMARY, COLOR_PRIMARY_LIGHT,
+  COLOR_SURFACE, COLOR_TEXT_MAIN, COLOR_TEXT_SUB, COLOR_ORIGIN, COLOR_DEST,
+  COLOR_BG, TRAFFIC_COLOR_MAP,
+} from "../colors";
 import { formatDistance, formatDuration } from "../utils/Utils";
+import type { RecommendedPlace, RecommendedRoute } from "../hooks/Userecommendedroute";
 
-interface RoutePanelProps {
-  routeState:  RouteState;
-  onSetOrigin: (point: RoutePoint | null) => void;
-  onSetDest:   (point: RoutePoint | null) => void;
-  onSetResult: (result: RouteResult | null) => void;
-  onSetLoading:(isLoading: boolean) => void;
-  onSetError:  (msg: string) => void;
-  userLat:     number;
-  userLng:     number;
-}
+// ── [CONFIG] ──────────────────────────────────────────────
 
-/** [API] 카카오 Geocoder — 주소 문자열 → 좌표 변환 */
+const TA_API_KEY = import.meta.env.VITE_TRIPADVISOR_API_KEY as string;
+
+const WAYPOINT_CATS: { code: string; category: Category }[] = [
+  { code: "AT4", category: "명소" },
+  { code: "CT1", category: "문화" },
+  { code: "CE7", category: "카페" },
+];
+
+const CATEGORY_ICON: Record<Category, string> = {
+  카페: "☕", 갤러리: "🖼", 공원: "🌿", 명소: "📸", 문화: "🎨", 거리: "🛍",
+};
+
+const CATEGORY_COLOR: Record<Category, string> = {
+  카페: "#b45309", 갤러리: "#7c3aed", 공원: "#16a34a",
+  명소: "#1d4ed8", 문화: "#0e7490",  거리: "#be185d",
+};
+
+// ── [UTIL] ────────────────────────────────────────────────
+
+const taUrl = (path: string) =>
+  import.meta.env.DEV
+    ? `/vite-proxy/tripadvisor/v1/${path}`
+    : `${import.meta.env.VITE_BACKEND_URL}/api/tripadvisor/${path}`;
+
 const geocodeAddress = (query: string): Promise<RoutePoint> =>
   new Promise((resolve, reject) => {
     const geocoder = new window.kakao.maps.services.Geocoder();
-    geocoder.addressSearch(query, (result, status) => {
-      if (status === window.kakao.maps.services.Status.OK && result[0]) {
-        resolve({
-          label: result[0].address_name,
-          lat:   parseFloat(result[0].y),
-          lng:   parseFloat(result[0].x),
-        });
-      } else {
-        reject(new Error(`"${query}" 주소를 찾을 수 없어요`));
-      }
+    geocoder.addressSearch(query, (result: any[], status: string) => {
+      if (status === window.kakao.maps.services.Status.OK && result[0])
+        resolve({ label: result[0].address_name, lat: parseFloat(result[0].y), lng: parseFloat(result[0].x) });
+      else reject(new Error(`"${query}" 주소를 찾을 수 없어요`));
     });
-});
-
-const fetchCarRoute = async (
-  origin:      RoutePoint,
-  destination: RoutePoint,
-): Promise<RouteResult> => {
-  const params = new URLSearchParams({
-    origin:      `${origin.lng},${origin.lat}`,
-    destination: `${destination.lng},${destination.lat}`,
-    priority:    "RECOMMEND",
-    car_fuel:    "GASOLINE",
-    car_hipass:  "false",
-    alternatives:"false",
-    road_details:"false",
   });
 
-  const res = await fetch(`${import.meta.env.VITE_KAKAO_DIRECTIONS_URL}?${params}`, {
-    headers: { Authorization: `KakaoAK ${import.meta.env.VITE_KAKAO_REST_API_KEY}` },
+// fetchCarRoute는 buildManualRoutes 내부에서 직접 처리
+
+const fetchTaLocationId = async (name: string, lat: number, lng: number): Promise<string | null> => {
+  try {
+    const params = new URLSearchParams({ searchQuery: name, latLong: `${lat},${lng}`, language: "ko", key: TA_API_KEY });
+    const res = await fetch(`${taUrl("location/search")}?${params}`);
+    if (!res.ok) return null;
+    return (await res.json()).data?.[0]?.location_id ?? null;
+  } catch { return null; }
+};
+
+const fetchTaDetail = async (id: string): Promise<{ rating: number; reviews: number } | null> => {
+  try {
+    const params = new URLSearchParams({ language: "ko", key: TA_API_KEY });
+    const res = await fetch(`${taUrl(`location/${id}/details`)}?${params}`);
+    if (!res.ok) return null;
+    const json = await res.json();
+    return { rating: parseFloat(json.rating ?? "0"), reviews: parseInt(json.num_reviews ?? "0", 10) };
+  } catch { return null; }
+};
+
+interface KakaoPlaceItem {
+  id: string; place_name: string; address_name: string; x: string; y: string; distance: string;
+}
+
+
+
+// ── [지도 렌더링] ─────────────────────────────────────────
+
+const drawOnMap = (
+  roads:           RouteResult["roads"],
+  origin:          { lat: number; lng: number; label: string },
+  dest:            { lat: number; lng: number; label: string },
+  waypoints:       { lat: number; lng: number; name: string }[],
+  kakaoMapRef:     React.MutableRefObject<KakaoMapInstance | null>,
+  polylineListRef: React.MutableRefObject<KakaoPolyline[]>,
+  overlayListRef:  React.MutableRefObject<KakaoOverlay[]>,
+) => {
+  if (!kakaoMapRef.current) return;
+  polylineListRef.current.forEach(p => p.setMap(null));
+  overlayListRef.current.forEach(o => o.setMap(null));
+  polylineListRef.current = []; overlayListRef.current = [];
+
+  roads.forEach(road => {
+    const path: object[] = [];
+    for (let i = 0; i < road.vertexes.length - 1; i += 2)
+      path.push(new window.kakao.maps.LatLng(road.vertexes[i + 1], road.vertexes[i]));
+    if (path.length < 2) return;
+    polylineListRef.current.push(new window.kakao.maps.Polyline({
+      map: kakaoMapRef.current!, path, strokeWeight: 6,
+      strokeColor: TRAFFIC_COLOR_MAP[road.traffic_state] ?? TRAFFIC_COLOR_MAP[0],
+      strokeOpacity: 0.9, strokeStyle: "solid",
+    }));
   });
 
-  if (!res.ok) throw new Error(`API 오류: ${res.status}`);
-
-  const data: DirectionsResponse = await res.json();
-  const route = data.routes?.[0];
-
-  if (!route || route.result_code !== 0) {
-    throw new Error(route?.result_msg ?? "경로를 찾을 수 없어요");
-  }
-
-  // [NOTE] 모든 section의 roads를 하나로 flatten
-  const roads = route.sections.flatMap(s => s.roads);
-
-  return {
-    distanceMeter: route.summary.distance,
-    durationSec:   route.summary.duration,
-    taxiFare:      route.summary.fare.taxi,
-    tollFare:      route.summary.fare.toll,
-    roads,
+  const makePin = (lat: number, lng: number, color: string, emoji: string, label: string) => {
+    const el = document.createElement("div");
+    el.style.cssText = "display:flex;flex-direction:column;align-items:center;";
+    el.innerHTML = `
+      <div style="background:#fff;border-radius:8px;padding:3px 8px;margin-bottom:4px;white-space:nowrap;box-shadow:0 2px 8px rgba(0,0,0,0.12);font-size:11px;font-weight:700;border:1.5px solid ${color};font-family:'Noto Sans KR',sans-serif;">${label}</div>
+      <div style="width:28px;height:28px;border-radius:50% 50% 50% 0;transform:rotate(-45deg);background:${color};border:2.5px solid #fff;box-shadow:0 2px 8px rgba(0,0,0,0.2);display:flex;align-items:center;justify-content:center;">
+        <span style="transform:rotate(45deg);font-size:12px;">${emoji}</span>
+      </div>`;
+    overlayListRef.current.push(new window.kakao.maps.CustomOverlay({
+      map: kakaoMapRef.current!, content: el, yAnchor: 1.1, zIndex: 15,
+      position: new window.kakao.maps.LatLng(lat, lng),
+    }));
   };
+
+  makePin(origin.lat, origin.lng, COLOR_ORIGIN, "🟢", origin.label);
+  waypoints.forEach((p, i) => makePin(p.lat, p.lng, COLOR_PRIMARY, `${i + 1}`, `${i + 1}. ${p.name}`));
+  makePin(dest.lat, dest.lng, COLOR_DEST, "🔴", dest.label);
+
+  const bounds = new window.kakao.maps.LatLngBounds();
+  roads.forEach(road => {
+    for (let i = 0; i < road.vertexes.length - 1; i += 2)
+      bounds.extend(new window.kakao.maps.LatLng(road.vertexes[i + 1], road.vertexes[i]));
+  });
+  kakaoMapRef.current!.setBounds(bounds, 60, 60, 60, 60);
+};
+
+// ── [SUB COMPONENTS] ──────────────────────────────────────
+
+// 경로 결과 요약 카드
+const RouteResultCard: FC<{
+  result:    RouteResult | { distanceMeter: number; durationSec: number; taxiFare: number; tollFare: number; roads: any[] };
+  origin:    string;
+  dest:      string;
+  waypoints: { name: string }[];
+}> = ({ result, origin, dest, waypoints }) => (
+  <div style={{ background: COLOR_SURFACE, borderRadius: 14, border: `1.5px solid ${COLOR_PRIMARY}`, overflow: "hidden" }}>
+    <div style={{ background: COLOR_PRIMARY_LIGHT, padding: "14px 16px", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+      <div>
+        <div style={{ fontSize: 22, fontWeight: 900, color: COLOR_PRIMARY }}>{formatDuration(result.durationSec)}</div>
+        <div style={{ fontSize: 12, color: COLOR_TEXT_SUB, marginTop: 2 }}>총 {formatDistance(result.distanceMeter)}</div>
+      </div>
+      <div style={{ textAlign: "right" }}>
+        {result.taxiFare > 0 && <div style={{ fontSize: 13, fontWeight: 700, color: COLOR_TEXT_MAIN }}>🚕 {result.taxiFare.toLocaleString()}원</div>}
+        {result.tollFare > 0 && <div style={{ fontSize: 11, color: COLOR_TEXT_SUB, marginTop: 2 }}>통행료 {result.tollFare.toLocaleString()}원</div>}
+      </div>
+    </div>
+    <div style={{ padding: "12px 16px", display: "flex", flexDirection: "column", gap: 6 }}>
+      {[{ label: origin, isOrigin: true }, ...waypoints.map(w => ({ label: w.name, isOrigin: false })), { label: dest, isOrigin: false }].map((item, i, arr) => (
+        <div key={i}>
+          {i > 0 && <div style={{ width: 2, height: 10, background: COLOR_BORDER, marginLeft: 3, marginBottom: 6 }} />}
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <div style={{ width: 8, height: 8, flexShrink: 0, borderRadius: i === 0 ? "50%" : i === arr.length - 1 ? 2 : "50%", background: i === 0 ? COLOR_ORIGIN : i === arr.length - 1 ? COLOR_DEST : COLOR_PRIMARY }} />
+            <div style={{ fontSize: 12, color: COLOR_TEXT_MAIN, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{item.label}</div>
+          </div>
+        </div>
+      ))}
+    </div>
+    <div style={{ padding: "8px 16px 14px", display: "flex", gap: 12, flexWrap: "wrap" }}>
+      {([0, 1, 2, 3] as const).map(state => (
+        <div key={state} style={{ display: "flex", alignItems: "center", gap: 4 }}>
+          <div style={{ width: 20, height: 4, borderRadius: 2, background: TRAFFIC_COLOR_MAP[state] }} />
+          <span style={{ fontSize: 10, color: COLOR_TEXT_SUB }}>{["원활", "서행", "정체", "매우정체"][state]}</span>
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+// 추천 경로 후보 카드
+const RouteOptionCard: FC<{
+  route:      RecommendedRoute;
+  isSelected: boolean;
+  onSelect:   () => void;
+}> = ({ route, isSelected, onSelect }) => (
+  <div
+    onClick={onSelect}
+    style={{
+      borderRadius: 14, border: `2px solid ${isSelected ? COLOR_PRIMARY : COLOR_BORDER}`,
+      background: isSelected ? COLOR_PRIMARY_LIGHT : COLOR_SURFACE,
+      padding: "14px 16px", cursor: "pointer", transition: "all 0.2s",
+      boxShadow: isSelected ? `0 4px 16px ${COLOR_PRIMARY}28` : "0 1px 4px rgba(0,0,0,0.06)",
+    }}
+  >
+    {/* 헤더 */}
+    <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 10 }}>
+      <span style={{ fontSize: 20 }}>{route.emoji}</span>
+      <div style={{ flex: 1 }}>
+        <div style={{ fontSize: 14, fontWeight: 800, color: isSelected ? COLOR_PRIMARY : COLOR_TEXT_MAIN }}>{route.label}</div>
+        <div style={{ fontSize: 11, color: COLOR_TEXT_SUB, marginTop: 1 }}>{route.description}</div>
+      </div>
+      {isSelected && (
+        <div style={{ width: 20, height: 20, borderRadius: "50%", background: COLOR_PRIMARY, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
+          <span style={{ fontSize: 11, color: "#fff" }}>✓</span>
+        </div>
+      )}
+    </div>
+
+    {/* 거리·시간 요약 */}
+    <div style={{ display: "flex", gap: 12, marginBottom: 10 }}>
+      {route.totalDuration > 0 && (
+        <div style={{ fontSize: 13, fontWeight: 700, color: COLOR_PRIMARY }}>{formatDuration(route.totalDuration)}</div>
+      )}
+      {route.totalDistance > 0 && (
+        <div style={{ fontSize: 12, color: COLOR_TEXT_SUB }}>{formatDistance(route.totalDistance)}</div>
+      )}
+      {route.taxiFare > 0 && (
+        <div style={{ fontSize: 12, color: COLOR_TEXT_SUB }}>🚕 {route.taxiFare.toLocaleString()}원</div>
+      )}
+    </div>
+
+    {/* 경유지 칩 */}
+    <div style={{ display: "flex", gap: 5, flexWrap: "wrap" }}>
+      {route.places.map((p, i) => (
+        <div key={p.id} style={{ display: "flex", alignItems: "center", gap: 4, background: `${CATEGORY_COLOR[p.category]}14`, borderRadius: 8, padding: "3px 8px", border: `1px solid ${CATEGORY_COLOR[p.category]}30` }}>
+          <span style={{ fontSize: 9, fontWeight: 700, color: COLOR_TEXT_SUB }}>{i + 1}</span>
+          <span style={{ fontSize: 10 }}>{CATEGORY_ICON[p.category]}</span>
+          <span style={{ fontSize: 11, fontWeight: 600, color: COLOR_TEXT_MAIN, maxWidth: 64, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{p.name}</span>
+          {p.rating > 0 && <span style={{ fontSize: 9, color: "#f59e0b", fontWeight: 700 }}>★{p.rating.toFixed(1)}</span>}
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+// ── [MAIN COMPONENT] ──────────────────────────────────────
+
+interface RoutePanelProps {
+  routeState:      RouteState;
+  onSetOrigin:     (p: RoutePoint | null) => void;
+  onSetDest:       (p: RoutePoint | null) => void;
+  onSetResult:     (r: RouteResult | null) => void;
+  onSetLoading:    (v: boolean) => void;
+  onSetError:      (m: string) => void;
+  userLat:         number;
+  userLng:         number;
+  kakaoMapRef:     React.MutableRefObject<KakaoMapInstance | null>;
+  polylineListRef: React.MutableRefObject<KakaoPolyline[]>;
+  overlayListRef:  React.MutableRefObject<KakaoOverlay[]>;
+  // 추천 경로 데이터 (RouteScreen에서 전달)
+  recRoutes:       RecommendedRoute[];
+  recIsLoading:    boolean;
+  recError:        string | null;
+  recRefetch:      () => void;
+}
+
+// ── [직접 입력용 경로 후보 3개 생성] ─────────────────────
+//
+// 경유지 최대 5개, 평점 상위 풀에서 선정 방식을 달리해 진짜 다른 3개 경로 생성
+//
+// A코스 — 순수 고평점 TOP5
+//   평점 점수(rating × log(reviews))만으로 정렬, 상위 5개 선택
+//   → 가장 유명하고 검증된 장소 위주
+//
+// B코스 — 거리 효율 TOP5
+//   출발↔도착 사이 선분과의 수직거리(이탈도) 최소화 + 평점 보정
+//   → 돌아가지 않고 동선 효율이 높은 장소 위주
+//
+// C코스 — 카테고리 다양성 TOP5
+//   카테고리별 1위씩 먼저 채우고 나머지는 점수 순으로 채움
+//   → A·B와 최대한 다른 장소 조합
+
+const MAX_WP = 5;
+const WEIGHT: Record<Category, number> = { 명소: 1.4, 문화: 1.3, 공원: 1.2, 카페: 1.1, 갤러리: 1.1, 거리: 1.0 };
+
+/** 점(px,py)과 선분(ax,ay)→(bx,by) 사이의 수직거리 */
+const pointToSegmentDist = (
+  px: number, py: number,
+  ax: number, ay: number,
+  bx: number, by: number,
+): number => {
+  const dx = bx - ax; const dy = by - ay;
+  if (dx === 0 && dy === 0) return Math.hypot(px - ax, py - ay);
+  const t = Math.max(0, Math.min(1, ((px - ax) * dx + (py - ay) * dy) / (dx * dx + dy * dy)));
+  return Math.hypot(px - ax - t * dx, py - ay - t * dy);
+};
+
+const buildManualRoutes = async (
+  origin: RoutePoint,
+  dest:   RoutePoint,
+): Promise<RecommendedRoute[]> => {
+  // ── Step 1: 출발↔도착 중간 지점 기준 카카오 검색
+  const midLat = (origin.lat + dest.lat) / 2;
+  const midLng = (origin.lng + dest.lng) / 2;
+  const radius = Math.min(
+    Math.round(Math.hypot(origin.lat - dest.lat, origin.lng - dest.lng) * 111000 / 2),
+    4000,
+  );
+  const ps     = new (window.kakao.maps.services as any).Places();
+  const center = new window.kakao.maps.LatLng(midLat, midLng);
+  const rawPlaces: { item: KakaoPlaceItem; category: Category }[] = [];
+  const seenIds = new Set<string>();
+
+  await Promise.all(WAYPOINT_CATS.map(({ code, category }) =>
+    new Promise<void>(resolve => {
+      ps.categorySearch(code, (result: KakaoPlaceItem[], status: string) => {
+        if (status === (window.kakao.maps.services as any).Status.OK) {
+          result.forEach(item => {
+            if (!seenIds.has(item.id)) { seenIds.add(item.id); rawPlaces.push({ item, category }); }
+          });
+        }
+        resolve();
+      }, { location: center, radius: Math.max(radius, 500), sort: "distance" });
+    })
+  ));
+
+  if (rawPlaces.length === 0) return [];
+
+  // ── Step 2: Tripadvisor 평점 보강 (상위 20개까지 조회)
+  const top = rawPlaces.slice(0, 20);
+  const idResults     = await Promise.allSettled(top.map(({ item }) =>
+    fetchTaLocationId(item.place_name, parseFloat(item.y), parseFloat(item.x))
+  ));
+  const detailResults = await Promise.allSettled(idResults.map(r =>
+    r.status === "fulfilled" && r.value ? fetchTaDetail(r.value) : Promise.resolve(null)
+  ));
+
+  const enriched: RecommendedPlace[] = top.map(({ item, category }, i) => {
+    const d       = detailResults[i].status === "fulfilled" ? detailResults[i].value : null;
+    const rating  = d?.rating  ?? 0;
+    const reviews = d?.reviews ?? 0;
+    const dist    = parseInt(item.distance, 10);
+    // 기본 평점 점수 (평점 × 카테고리가중치 × log(리뷰수))
+    const ratingScore = rating > 0 ? rating * WEIGHT[category] * Math.log10(reviews + 1) : 0;
+    // 동선 이탈도 (출발↔도착 선분과의 거리, 작을수록 좋음)
+    const detour = pointToSegmentDist(
+      parseFloat(item.y), parseFloat(item.x),
+      origin.lat, origin.lng,
+      dest.lat,   dest.lng,
+    ) * 111000; // 도 → 미터 근사
+
+    return {
+      id: parseInt(item.id, 10), name: item.place_name, category,
+      rating, reviews,
+      score: ratingScore,          // A코스 기준
+      district: item.address_name.split(" ").slice(0, 2).join(" "),
+      lat: parseFloat(item.y), lng: parseFloat(item.x), distance: dist,
+      // 추가 필드 (선정 시에만 사용)
+      _detour: detour,
+      _ratingScore: ratingScore,
+    } as RecommendedPlace & { _detour: number; _ratingScore: number };
+  }) as (RecommendedPlace & { _detour: number; _ratingScore: number })[];
+
+  // 평점 있는 곳만 사용 (없으면 거리 가까운 순으로 대체)
+  const scored  = enriched.filter(p => p._ratingScore > 0);
+  const fallback = scored.length >= 3 ? scored : enriched;
+
+  // ── Step 3: 코스별 선정 로직
+  // [A] 순수 고평점 TOP5 — 평점 점수 내림차순
+  const selectA = (): RecommendedPlace[] =>
+    [...fallback]
+      .sort((a, b) => b._ratingScore - a._ratingScore)
+      .slice(0, MAX_WP);
+
+  // [B] 거리 효율 TOP5 — 이탈도 최소 + 평점 보정
+  //     정렬 기준: (이탈도 / 500m) - 평점점수  (작을수록 우선)
+  const selectB = (): RecommendedPlace[] =>
+    [...fallback]
+      .sort((a, b) => {
+        const scoreA = (a._detour / 500) - a._ratingScore;
+        const scoreB = (b._detour / 500) - b._ratingScore;
+        return scoreA - scoreB;
+      })
+      .slice(0, MAX_WP);
+
+  // [C] 카테고리 다양성 TOP5 — 카테고리별 최고점 1개씩, 나머지 점수 순
+  const selectC = (): RecommendedPlace[] => {
+    const byScore  = [...fallback].sort((a, b) => b._ratingScore - a._ratingScore);
+    const selected: RecommendedPlace[] = [];
+    const usedCats = new Set<Category>();
+    for (const p of byScore) {
+      if (selected.length >= MAX_WP) break;
+      if (!usedCats.has(p.category)) { usedCats.add(p.category); selected.push(p); }
+    }
+    for (const p of byScore) {
+      if (selected.length >= MAX_WP) break;
+      if (!selected.find(s => s.id === p.id)) selected.push(p);
+    }
+    return selected;
+  };
+
+  const COURSES: { label: string; description: string; emoji: string; places: RecommendedPlace[] }[] = [
+    { label: "고평점 코스",    description: "Tripadvisor 평점 TOP 5 장소만 방문",      emoji: "⭐", places: selectA() },
+    { label: "동선 효율 코스", description: "돌아가지 않고 경로 위 평점 높은 장소 위주", emoji: "🗺", places: selectB() },
+    { label: "다양성 코스",    description: "카테고리별 1위씩 골고루 방문",              emoji: "🎨", places: selectC() },
+  ];
+
+  // ── Step 4: Directions API 병렬 호출
+  const results = await Promise.allSettled(
+    COURSES.map(async course => {
+      if (course.places.length === 0) throw new Error("경유지 없음");
+      const wps    = course.places.map(p => `${p.lng},${p.lat}`).join("|");
+      const params = new URLSearchParams({
+        origin:       `${origin.lng},${origin.lat}`,
+        destination:  `${dest.lng},${dest.lat}`,
+        priority:     "RECOMMEND", car_fuel: "GASOLINE", car_hipass: "false",
+        alternatives: "false",     road_details: "false",
+        ...(wps ? { waypoints: wps } : {}),
+      });
+      const res = await fetch(`${import.meta.env.VITE_KAKAO_DIRECTIONS_URL}?${params}`, {
+        headers: { Authorization: `KakaoAK ${import.meta.env.VITE_KAKAO_REST_API_KEY}` },
+      });
+      if (!res.ok) throw new Error(`Directions API 오류: ${res.status}`);
+      const data  = await res.json();
+      const route = data.routes?.[0];
+      if (!route || route.result_code !== 0) throw new Error(route?.result_msg ?? "경로 없음");
+
+      return {
+        label:         course.label,
+        description:   course.description,
+        emoji:         course.emoji,
+        places:        course.places,
+        totalDistance: route.summary.distance,
+        totalDuration: route.summary.duration,
+        roads:         route.sections.flatMap((s: any) => s.roads),
+        taxiFare:      route.summary.fare.taxi,
+        tollFare:      route.summary.fare.toll,
+      } as RecommendedRoute;
+    })
+  );
+
+  return results
+    .filter(r => r.status === "fulfilled")
+    .map(r => (r as PromiseFulfilledResult<RecommendedRoute>).value);
 };
 
 const RoutePanel: FC<RoutePanelProps> = ({
   routeState, onSetOrigin, onSetDest, onSetResult, onSetLoading, onSetError,
-  userLat, userLng,
+  userLat, userLng, kakaoMapRef, polylineListRef, overlayListRef,
+  recRoutes, recIsLoading, recError, recRefetch,
 }) => {
+  const [panelTab,    setPanelTab]    = useState<"manual" | "recommend">("recommend");
   const [originInput, setOriginInput] = useState<string>("");
   const [destInput,   setDestInput]   = useState<string>("");
 
-  // [HANDLER] 경로 탐색 실행
-  // 1. Geocoder로 주소 → 좌표 변환
-  // 2. fetchCarRoute로 카카오모빌리티 Directions API 호출
+  // 현위치 기반 추천 경로 선택
+  const [selectedRouteIdx, setSelectedRouteIdx] = useState<number | null>(null);
+
+  // 직접 입력 경로 후보 상태
+  const [manualRoutes,      setManualRoutes]      = useState<RecommendedRoute[]>([]);
+  const [manualLoading,     setManualLoading]      = useState<boolean>(false);
+  const [manualError,       setManualError]        = useState<string | null>(null);
+  const [selectedManualIdx, setSelectedManualIdx]  = useState<number | null>(null);
+
+  // 현위치 기반 추천 경로 카드 선택 → 지도에 표시
+  const handleSelectRoute = useCallback((idx: number) => {
+    const route = recRoutes[idx];
+    if (!route) return;
+    setSelectedRouteIdx(idx);
+    const dest = route.places[route.places.length - 1];
+    drawOnMap(route.roads, { lat: userLat, lng: userLng, label: "현재 위치" }, { lat: dest.lat, lng: dest.lng, label: dest.name }, route.places.slice(0, -1), kakaoMapRef, polylineListRef, overlayListRef);
+  }, [recRoutes, userLat, userLng, kakaoMapRef, polylineListRef, overlayListRef]);
+
+  // 직접 입력 후보 경로 선택 → 지도에 표시
+  const handleSelectManualRoute = useCallback((idx: number) => {
+    const route = manualRoutes[idx];
+    if (!route) return;
+    setSelectedManualIdx(idx);
+    const origin = routeState.origin!;
+    const dest   = routeState.destination!;
+    drawOnMap(route.roads, origin, dest, route.places, kakaoMapRef, polylineListRef, overlayListRef);
+  }, [manualRoutes, routeState, kakaoMapRef, polylineListRef, overlayListRef]);
+
+  // 직접 입력 — 주소 변환 후 후보 경로 3개 생성
   const handleSearch = useCallback(async () => {
-    if (!originInput.trim() || !destInput.trim()) {
-      onSetError("출발지와 도착지를 모두 입력해주세요");
-      return;
-    }
-    onSetLoading(true);
-    onSetError("");
-    onSetResult(null);
+    if (!originInput.trim() || !destInput.trim()) { onSetError("출발지와 도착지를 모두 입력해주세요"); return; }
+    setManualLoading(true); setManualError(null); setManualRoutes([]); setSelectedManualIdx(null);
+    onSetError(""); onSetResult(null);
+    // 지도 초기화
+    polylineListRef.current.forEach(p => p.setMap(null)); overlayListRef.current.forEach(o => o.setMap(null));
+    polylineListRef.current = []; overlayListRef.current = [];
     try {
-      const [origin, dest] = await Promise.all([
-        geocodeAddress(originInput),
-        geocodeAddress(destInput),
-      ]);
-      onSetOrigin(origin);
-      onSetDest(dest);
-      const result = await fetchCarRoute(origin, dest);
-      onSetResult(result);
+      const [origin, dest] = await Promise.all([geocodeAddress(originInput), geocodeAddress(destInput)]);
+      onSetOrigin(origin); onSetDest(dest);
+      const routes = await buildManualRoutes(origin, dest);
+      if (routes.length === 0) setManualError("추천 경로를 생성하지 못했어요. 다른 주소를 입력해보세요.");
+      else setManualRoutes(routes);
     } catch (e) {
       onSetError((e as Error).message);
     } finally {
-      onSetLoading(false);
+      setManualLoading(false);
     }
-  }, [originInput, destInput, onSetOrigin, onSetDest, onSetResult, onSetLoading, onSetError]);
+  }, [originInput, destInput, onSetOrigin, onSetDest, onSetResult, onSetError, polylineListRef, overlayListRef]);
 
-  // [HANDLER] 현재 위치를 출발지로 설정
   const handleUseCurrentLoc = useCallback(() => {
     onSetOrigin({ label: "현재 위치", lat: userLat, lng: userLng });
     setOriginInput("현재 위치");
   }, [userLat, userLng, onSetOrigin]);
 
-  // [HANDLER] 출발/도착 스왑
   const handleSwap = useCallback(() => {
-    const prevOrigin = routeState.origin;
-    const prevDest   = routeState.destination;
-    onSetOrigin(prevDest);
-    onSetDest(prevOrigin);
-    setOriginInput(prevDest?.label ?? "");
-    setDestInput(prevOrigin?.label ?? "");
-    onSetResult(null);
-  }, [routeState.origin, routeState.destination, onSetOrigin, onSetDest, onSetResult]);
+    onSetOrigin(routeState.destination); onSetDest(routeState.origin);
+    setOriginInput(routeState.destination?.label ?? ""); setDestInput(routeState.origin?.label ?? "");
+    onSetResult(null); setManualRoutes([]); setSelectedManualIdx(null);
+  }, [routeState, onSetOrigin, onSetDest, onSetResult]);
 
-  const { result, isLoading, errorMsg } = routeState;
+  // 탭 전환 시 지도 초기화
+  const handlePanelTab = (tab: "manual" | "recommend") => {
+    polylineListRef.current.forEach(p => p.setMap(null));
+    overlayListRef.current.forEach(o => o.setMap(null));
+    polylineListRef.current = []; overlayListRef.current = [];
+    setSelectedRouteIdx(null); setSelectedManualIdx(null);
+    onSetResult(null);
+    setPanelTab(tab);
+  };
+
+  const { errorMsg } = routeState;
+  const selectedRoute       = selectedRouteIdx  !== null ? recRoutes[selectedRouteIdx]     : null;
+  const selectedManualRoute = selectedManualIdx !== null ? manualRoutes[selectedManualIdx]  : null;
 
   return (
-    <div style={{ padding: "16px 16px 24px", display: "flex", flexDirection: "column", gap: 12 }}>
+    <div style={{ display: "flex", flexDirection: "column" }}>
 
-      {/* 출발지/도착지 입력 박스 */}
-      <div style={{ background: COLOR_SURFACE, borderRadius: 14, border: `1px solid ${COLOR_BORDER}`, overflow: "hidden" }}>
-
-        {/* 출발지 */}
-        <div style={{ display: "flex", alignItems: "center", padding: "11px 14px", gap: 10, borderBottom: `1px solid ${COLOR_BORDER}` }}>
-          <div style={{ width: 10, height: 10, borderRadius: "50%", background: COLOR_ORIGIN, flexShrink: 0 }} />
-          <input
-            value={originInput}
-            onChange={e => setOriginInput(e.target.value)}
-            onKeyDown={e => e.key === "Enter" && handleSearch()}
-            placeholder="출발지 주소 입력"
-            style={{ flex: 1, border: "none", outline: "none", fontSize: 13, color: COLOR_TEXT_MAIN, background: "transparent", fontFamily: "'Noto Sans KR', sans-serif" }}
-          />
-          <button onClick={handleUseCurrentLoc} title="현재 위치로 설정" style={{ background: "none", border: "none", cursor: "pointer", fontSize: 16, padding: 0, lineHeight: 1 }}>📍</button>
-        </div>
-
-        {/* 스왑 버튼 */}
-        <div style={{ position: "relative", height: 0, zIndex: 5 }}>
-          <button onClick={handleSwap} style={{ position: "absolute", right: 14, top: -14, width: 28, height: 28, borderRadius: "50%", border: `1px solid ${COLOR_BORDER}`, background: COLOR_SURFACE, cursor: "pointer", fontSize: 14, display: "flex", alignItems: "center", justifyContent: "center", boxShadow: "0 2px 6px rgba(0,0,0,0.08)" }}>↕</button>
-        </div>
-
-        {/* 도착지 */}
-        <div style={{ display: "flex", alignItems: "center", padding: "11px 14px", gap: 10 }}>
-          <div style={{ width: 10, height: 10, borderRadius: 2, background: COLOR_DEST, flexShrink: 0 }} />
-          <input
-            value={destInput}
-            onChange={e => setDestInput(e.target.value)}
-            onKeyDown={e => e.key === "Enter" && handleSearch()}
-            placeholder="도착지 주소 입력"
-            style={{ flex: 1, border: "none", outline: "none", fontSize: 13, color: COLOR_TEXT_MAIN, background: "transparent", fontFamily: "'Noto Sans KR', sans-serif" }}
-          />
-        </div>
+      {/* 상단 탭 */}
+      <div style={{ display: "flex", borderBottom: `1px solid ${COLOR_BORDER}`, background: COLOR_SURFACE, flexShrink: 0 }}>
+        {(["recommend", "manual"] as const).map(tab => (
+          <button
+            key={tab}
+            onClick={() => handlePanelTab(tab)}
+            style={{
+              flex: 1, padding: "11px 0", border: "none", background: "none", cursor: "pointer",
+              fontSize: 13, fontWeight: panelTab === tab ? 800 : 500,
+              color: panelTab === tab ? COLOR_PRIMARY : COLOR_TEXT_SUB,
+              borderBottom: `2.5px solid ${panelTab === tab ? COLOR_PRIMARY : "transparent"}`,
+              fontFamily: "'Noto Sans KR', sans-serif", transition: "all 0.18s",
+            }}
+          >
+            {tab === "recommend" ? "⭐ 추천 경로" : "🔍 직접 입력"}
+          </button>
+        ))}
       </div>
 
-      {/* 오류 메시지 */}
-      {errorMsg && (
-        <div style={{ fontSize: 12, color: COLOR_DANGER, fontWeight: 600, paddingLeft: 4 }}>{errorMsg}</div>
+      {/* ── 추천 경로 탭 ── */}
+      {panelTab === "recommend" && (
+        <div style={{ padding: "16px 16px 32px", display: "flex", flexDirection: "column", gap: 12 }}>
+
+          {/* 로딩 */}
+          {recIsLoading && (
+            <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 14, padding: "40px 0" }}>
+              <div style={{ position: "relative", width: 44, height: 44 }}>
+                <div style={{ position: "absolute", inset: 0, border: `3px solid ${COLOR_PRIMARY}20`, borderRadius: "50%" }} />
+                <div style={{ position: "absolute", inset: 0, border: `3px solid ${COLOR_PRIMARY}`, borderTopColor: "transparent", borderRadius: "50%", animation: "spin 0.8s linear infinite" }} />
+              </div>
+              <div style={{ textAlign: "center" }}>
+                <div style={{ fontSize: 14, fontWeight: 700, color: COLOR_TEXT_MAIN, marginBottom: 4 }}>경로 후보 분석 중</div>
+                <div style={{ fontSize: 12, color: COLOR_TEXT_SUB }}>Tripadvisor 평점을 수집하고 있어요</div>
+              </div>
+              <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+            </div>
+          )}
+
+          {/* 에러 */}
+          {!recIsLoading && recError && (
+            <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 12, padding: "40px 0" }}>
+              <span style={{ fontSize: 36 }}>⚠️</span>
+              <span style={{ fontSize: 13, color: "#e53e3e", textAlign: "center" }}>{recError}</span>
+              <button onClick={recRefetch} style={{ padding: "9px 20px", borderRadius: 10, border: `1.5px solid ${COLOR_PRIMARY}`, background: "transparent", color: COLOR_PRIMARY, fontSize: 13, fontWeight: 700, cursor: "pointer", fontFamily: "'Noto Sans KR', sans-serif" }}>다시 시도</button>
+            </div>
+          )}
+
+          {/* 후보 경로 카드 목록 */}
+          {!recIsLoading && !recError && recRoutes.length > 0 && (
+            <>
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                <div style={{ fontSize: 13, fontWeight: 700, color: COLOR_TEXT_SUB }}>
+                  현위치 기반 추천 경로 <span style={{ color: COLOR_PRIMARY }}>{recRoutes.length}개</span>
+                </div>
+                <button onClick={() => { recRefetch(); setSelectedRouteIdx(null); }} style={{ background: "none", border: "none", cursor: "pointer", fontSize: 13, color: COLOR_TEXT_SUB, padding: 0 }}>🔄 재추천</button>
+              </div>
+
+              {/* 추천 기준 배지 */}
+              <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+                {["⭐ 평점 우선", "📍 거리 고려", "🎨 카테고리 다양성"].map(label => (
+                  <span key={label} style={{ fontSize: 10, fontWeight: 600, padding: "3px 8px", borderRadius: 6, background: COLOR_BG, color: COLOR_TEXT_SUB, border: `1px solid ${COLOR_BORDER}` }}>{label}</span>
+                ))}
+              </div>
+
+              {/* 후보 카드 */}
+              <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+                {recRoutes.map((route, i) => (
+                  <RouteOptionCard
+                    key={i} route={route}
+                    isSelected={selectedRouteIdx === i}
+                    onSelect={() => handleSelectRoute(i)}
+                  />
+                ))}
+              </div>
+
+              {/* 선택된 경로 결과 카드 */}
+              {selectedRoute && (
+                <RouteResultCard
+                  result={{ distanceMeter: selectedRoute.totalDistance, durationSec: selectedRoute.totalDuration, taxiFare: selectedRoute.taxiFare, tollFare: selectedRoute.tollFare, roads: selectedRoute.roads }}
+                  origin="현재 위치"
+                  dest={selectedRoute.places[selectedRoute.places.length - 1]?.name ?? "도착"}
+                  waypoints={selectedRoute.places.slice(0, -1)}
+                />
+              )}
+
+              <div style={{ padding: "10px 14px", background: COLOR_BG, borderRadius: 10, border: `1px solid ${COLOR_BORDER}` }}>
+                <div style={{ fontSize: 11, color: COLOR_TEXT_SUB, lineHeight: 1.6 }}>
+                  💡 경로 카드를 선택하면 지도에 경로가 표시돼요.<br />
+                  평점은 Tripadvisor 기준이며, 매칭되지 않은 장소는 점수 없이 표시돼요.
+                </div>
+              </div>
+            </>
+          )}
+        </div>
       )}
 
-      {/* 경로 탐색 버튼 */}
-      <button
-        onClick={handleSearch}
-        disabled={isLoading}
-        style={{ padding: "12px 0", borderRadius: 12, border: "none", background: isLoading ? COLOR_INACTIVE : COLOR_PRIMARY, color: "#fff", fontSize: 14, fontWeight: 700, cursor: isLoading ? "default" : "pointer", fontFamily: "'Noto Sans KR', sans-serif", transition: "all 0.18s" }}
-      >
-        {isLoading ? "경로 탐색 중..." : "🔍 경로 탐색"}
-      </button>
+      {/* ── 직접 입력 탭 ── */}
+      {panelTab === "manual" && (
+        <div style={{ padding: "16px 16px 32px", display: "flex", flexDirection: "column", gap: 12 }}>
 
-      {/* 경로 결과 카드 */}
-      {result && (
-        <div style={{ background: COLOR_SURFACE, borderRadius: 14, border: `1.5px solid ${COLOR_PRIMARY}`, overflow: "hidden" }}>
-
-          {/* 요약 헤더 */}
-          <div style={{ background: COLOR_PRIMARY_LIGHT, padding: "14px 16px", display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-            <div>
-              <div style={{ fontSize: 22, fontWeight: 900, color: COLOR_PRIMARY }}>{formatDuration(result.durationSec)}</div>
-              <div style={{ fontSize: 12, color: COLOR_TEXT_SUB, marginTop: 2 }}>총 {formatDistance(result.distanceMeter)}</div>
+          {/* 출발지/도착지 */}
+          <div style={{ background: COLOR_SURFACE, borderRadius: 14, border: `1px solid ${COLOR_BORDER}`, overflow: "hidden" }}>
+            <div style={{ display: "flex", alignItems: "center", padding: "11px 14px", gap: 10, borderBottom: `1px solid ${COLOR_BORDER}` }}>
+              <div style={{ width: 10, height: 10, borderRadius: "50%", background: COLOR_ORIGIN, flexShrink: 0 }} />
+              <input value={originInput} onChange={e => setOriginInput(e.target.value)} onKeyDown={e => e.key === "Enter" && handleSearch()} placeholder="출발지 주소 입력" style={{ flex: 1, border: "none", outline: "none", fontSize: 13, color: COLOR_TEXT_MAIN, background: "transparent", fontFamily: "'Noto Sans KR', sans-serif" }} />
+              <button onClick={handleUseCurrentLoc} style={{ background: "none", border: "none", cursor: "pointer", fontSize: 16, padding: 0 }}>📍</button>
             </div>
-            <div style={{ textAlign: "right" }}>
-              {result.taxiFare > 0 && (
-                <div style={{ fontSize: 13, fontWeight: 700, color: COLOR_TEXT_MAIN }}>🚕 {result.taxiFare.toLocaleString()}원</div>
-              )}
-              {result.tollFare > 0 && (
-                <div style={{ fontSize: 11, color: COLOR_TEXT_SUB, marginTop: 2 }}>통행료 {result.tollFare.toLocaleString()}원</div>
-              )}
+            <div style={{ position: "relative", height: 0, zIndex: 5 }}>
+              <button onClick={handleSwap} style={{ position: "absolute", right: 14, top: -14, width: 28, height: 28, borderRadius: "50%", border: `1px solid ${COLOR_BORDER}`, background: COLOR_SURFACE, cursor: "pointer", fontSize: 14, display: "flex", alignItems: "center", justifyContent: "center", boxShadow: "0 2px 6px rgba(0,0,0,0.08)" }}>↕</button>
+            </div>
+            <div style={{ display: "flex", alignItems: "center", padding: "11px 14px", gap: 10 }}>
+              <div style={{ width: 10, height: 10, borderRadius: 2, background: COLOR_DEST, flexShrink: 0 }} />
+              <input value={destInput} onChange={e => setDestInput(e.target.value)} onKeyDown={e => e.key === "Enter" && handleSearch()} placeholder="도착지 주소 입력" style={{ flex: 1, border: "none", outline: "none", fontSize: 13, color: COLOR_TEXT_MAIN, background: "transparent", fontFamily: "'Noto Sans KR', sans-serif" }} />
             </div>
           </div>
 
-          {/* 경유 정보 */}
-          <div style={{ padding: "12px 16px", display: "flex", flexDirection: "column", gap: 8 }}>
-            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-              <div style={{ width: 8, height: 8, borderRadius: "50%", background: COLOR_ORIGIN, flexShrink: 0 }} />
-              <div style={{ fontSize: 12, color: COLOR_TEXT_MAIN, flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{routeState.origin?.label}</div>
-            </div>
-            <div style={{ width: 2, height: 14, background: COLOR_BORDER, marginLeft: 3 }} />
-            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-              <div style={{ width: 8, height: 8, borderRadius: 2, background: COLOR_DEST, flexShrink: 0 }} />
-              <div style={{ fontSize: 12, color: COLOR_TEXT_MAIN, flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{routeState.destination?.label}</div>
-            </div>
-          </div>
+          {errorMsg && <div style={{ fontSize: 12, color: COLOR_DANGER, fontWeight: 600, paddingLeft: 4 }}>{errorMsg}</div>}
 
-          {/* 교통 혼잡도 범례 */}
-          <div style={{ padding: "8px 16px 14px", display: "flex", gap: 12, flexWrap: "wrap" }}>
-            {([0, 1, 2, 3] as const).map(state => {
-              const labels = ["원활", "서행", "정체", "매우정체"];
-              return (
-                <div key={state} style={{ display: "flex", alignItems: "center", gap: 4 }}>
-                  <div style={{ width: 20, height: 4, borderRadius: 2, background: TRAFFIC_COLOR_MAP[state] }} />
-                  <span style={{ fontSize: 10, color: COLOR_TEXT_SUB }}>{labels[state]}</span>
+          {/* 경로 탐색 버튼 */}
+          <button
+            onClick={handleSearch}
+            disabled={manualLoading}
+            style={{ padding: "12px 0", borderRadius: 12, border: "none", background: manualLoading ? COLOR_INACTIVE : COLOR_PRIMARY, color: "#fff", fontSize: 14, fontWeight: 700, cursor: manualLoading ? "default" : "pointer", fontFamily: "'Noto Sans KR', sans-serif", transition: "all 0.18s" }}
+          >
+            {manualLoading ? "경로 후보 생성 중..." : "🔍 경로 추천받기"}
+          </button>
+
+          {/* 직접 입력 — 로딩 */}
+          {manualLoading && (
+            <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 10, padding: "20px 0", color: COLOR_TEXT_SUB }}>
+              <div style={{ width: 28, height: 28, border: `3px solid ${COLOR_PRIMARY}`, borderTopColor: "transparent", borderRadius: "50%", animation: "spin 0.8s linear infinite" }} />
+              <span style={{ fontSize: 13 }}>Tripadvisor 평점으로 경로 후보 생성 중...</span>
+              <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+            </div>
+          )}
+
+          {/* 직접 입력 — 에러 */}
+          {!manualLoading && manualError && (
+            <div style={{ fontSize: 12, color: "#e53e3e", fontWeight: 600, textAlign: "center", padding: "8px 0" }}>{manualError}</div>
+          )}
+
+          {/* 직접 입력 — 후보 경로 3개 */}
+          {!manualLoading && manualRoutes.length > 0 && (
+            <>
+              <div style={{ fontSize: 13, fontWeight: 700, color: COLOR_TEXT_SUB, display: "flex", alignItems: "center", gap: 8 }}>
+                <span>추천 경로 <span style={{ color: COLOR_PRIMARY }}>{manualRoutes.length}개</span></span>
+                <button
+                  onClick={() => { setManualRoutes([]); setSelectedManualIdx(null); polylineListRef.current.forEach(p => p.setMap(null)); overlayListRef.current.forEach(o => o.setMap(null)); polylineListRef.current = []; overlayListRef.current = []; }}
+                  style={{ marginLeft: "auto", background: "none", border: "none", cursor: "pointer", fontSize: 12, color: COLOR_TEXT_SUB, padding: 0 }}
+                >
+                  초기화
+                </button>
+              </div>
+
+              <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+                {manualRoutes.map((route, i) => (
+                  <RouteOptionCard
+                    key={i} route={route}
+                    isSelected={selectedManualIdx === i}
+                    onSelect={() => handleSelectManualRoute(i)}
+                  />
+                ))}
+              </div>
+
+              {/* 선택된 경로 결과 카드 */}
+              {selectedManualRoute && (
+                <RouteResultCard
+                  result={{ distanceMeter: selectedManualRoute.totalDistance, durationSec: selectedManualRoute.totalDuration, taxiFare: selectedManualRoute.taxiFare, tollFare: selectedManualRoute.tollFare, roads: selectedManualRoute.roads }}
+                  origin={routeState.origin?.label ?? "출발"}
+                  dest={routeState.destination?.label ?? "도착"}
+                  waypoints={selectedManualRoute.places}
+                />
+              )}
+
+              <div style={{ padding: "10px 14px", background: COLOR_BG, borderRadius: 10, border: `1px solid ${COLOR_BORDER}` }}>
+                <div style={{ fontSize: 11, color: COLOR_TEXT_SUB, lineHeight: 1.6 }}>
+                  💡 경로 카드를 선택하면 지도에 경로가 표시돼요.<br />
+                  평점은 Tripadvisor 기준이며, 매칭되지 않은 장소는 점수 없이 표시돼요.
                 </div>
-              );
-            })}
-          </div>
+              </div>
+            </>
+          )}
         </div>
       )}
     </div>

--- a/Route_Planning/src/components/RouteScreen.tsx
+++ b/Route_Planning/src/components/RouteScreen.tsx
@@ -1,11 +1,12 @@
 // ═══════════════════════════════════════════════════════════
 // RouteScreen — 지도 풀스크린 + FAB + 하프 바텀 시트
+// [CHANGED] recommend + route 탭 → route 탭 하나로 통합
 // ═══════════════════════════════════════════════════════════
 
 import { useState, useRef, useEffect, useCallback, type FC } from "react";
 import { useGoogleLogin } from "@react-oauth/google";
 import type {
-  Tab, PlaceData, Place, UserLocation,
+  Tab, Place, UserLocation,
   RoutePoint, RouteState, RouteResult, Category,
 } from "../types/type";
 import type {
@@ -16,12 +17,13 @@ import {
   COLOR_BG, COLOR_BORDER, COLOR_INACTIVE,
   COLOR_PRIMARY, COLOR_SURFACE, COLOR_TEXT_MAIN, COLOR_TEXT_SUB,
 } from "../colors";
-import { toPlace } from "../utils/Utils";
+
+import { useKakaoNearby }      from "../hooks/Usekakaonearby";
+import { useRecommendedRoute } from "../hooks/Userecommendedroute";
 
 import PlaceCard  from "./PlaceCard";
-import RouteMap   from "./RouteMap";
-import RoutePanel from "./RoutePanel";
 import NearbyMap  from "./NearByMap";
+import RoutePanel from "./RoutePanel";
 
 // ═══════════════════════════════════════════════════════════
 // CONSTANTS
@@ -29,8 +31,6 @@ import NearbyMap  from "./NearByMap";
 
 const DEFAULT_LAT = 37.5665;
 const DEFAULT_LNG = 126.9780;
-
-// [THEME] 현위치 마커 파란색
 const COLOR_USER_PIN      = "#3B7DFF";
 const COLOR_USER_PIN_RING = "rgba(59,125,255,0.18)";
 
@@ -44,28 +44,22 @@ const CATEGORY_ICON: Record<Category, string> = {
   카페: "☕", 갤러리: "🖼", 공원: "🌿", 명소: "📸", 문화: "🎨", 거리: "🛍",
 };
 
-// [CONFIG] FAB 아이콘 — 오렌지 단색 SVG
 const IconNearby: FC = () => (
   <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
-    <circle cx="12" cy="12" r="3" />
-    <circle cx="12" cy="12" r="8" strokeOpacity="0.5" />
-    <line x1="12" y1="2"  x2="12" y2="5"  />
-    <line x1="12" y1="19" x2="12" y2="22" />
-    <line x1="2"  y1="12" x2="5"  y2="12" />
-    <line x1="19" y1="12" x2="22" y2="12" />
+    <circle cx="12" cy="12" r="3" /><circle cx="12" cy="12" r="8" strokeOpacity="0.5" />
+    <line x1="12" y1="2" x2="12" y2="5" /><line x1="12" y1="19" x2="12" y2="22" />
+    <line x1="2" y1="12" x2="5" y2="12" /><line x1="19" y1="12" x2="22" y2="12" />
   </svg>
 );
 
+// [CHANGED] route 탭 아이콘 — 별 + 경로 조합
 const IconRoute: FC = () => (
   <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
-    <circle cx="6"  cy="19" r="2" />
-    <circle cx="18" cy="5"  r="2" />
-    <path d="M6 17V9a6 6 0 0 1 6-6h2" />
-    <path d="M18 7v8a6 6 0 0 1-6 6H10" />
+    <circle cx="6" cy="19" r="2" /><circle cx="18" cy="5" r="2" />
+    <path d="M6 17V9a6 6 0 0 1 6-6h2" /><path d="M18 7v8a6 6 0 0 1-6 6H10" />
   </svg>
 );
 
-// [CONFIG] Google 로고 SVG
 const IconGoogle: FC = () => (
   <svg width="16" height="16" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
     <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
@@ -75,25 +69,22 @@ const IconGoogle: FC = () => (
   </svg>
 );
 
-// [CONFIG] FAB 메뉴 항목
+// [CHANGED] FAB 메뉴 2개로 단순화
 const MENU_ITEM_LIST: { id: Tab; Icon: FC; label: string }[] = [
   { id: "nearby", Icon: IconNearby, label: "주변 탐색" },
   { id: "route",  Icon: IconRoute,  label: "경로 탐색" },
 ];
 
-// [CONFIG] 바텀 시트 높이 (vh 단위)
+const TAB_HEADER: Record<string, { sub: string; main: string }> = {
+  nearby: { sub: "NEARBY EXPLORE", main: "근처 인기 장소 탐색" },
+  route:  { sub: "ROUTE PLANNING", main: "경로 탐색"           },
+};
+
 const SHEET_HEIGHT_HALF = 48;
 const SHEET_HEIGHT_FULL = 88;
+const DRAG_THRESHOLD    = 60;
 
-// [CONFIG] 드래그 임계값 (px)
-const DRAG_THRESHOLD = 60;
-
-// [TYPE] Google 유저 프로필
-type GoogleUserProfile = {
-  name:    string;
-  email:   string;
-  picture: string;
-};
+type GoogleUserProfile = { name: string; email: string; picture: string };
 
 declare global {
   interface Window {
@@ -111,38 +102,18 @@ declare global {
         Size:          new (w: number, h: number) => object;
         services: {
           Geocoder: new () => KakaoGeocoder;
-          Status: { OK: string };
+          Places:   new () => object;
+          Status:   { OK: string };
+          SortBy:   { DISTANCE: string };
         };
-        event: {
-          addListener: (target: object, type: string, handler: () => void) => void;
-        };
+        event: { addListener: (target: object, type: string, handler: () => void) => void };
       };
     };
   }
 }
 
 // ═══════════════════════════════════════════════════════════
-// MOCK DATA
-// [API] 실제 구현 시 Tripadvisor API 호출로 교체
-// ═══════════════════════════════════════════════════════════
-
-const PLACE_LIST: PlaceData[] = [
-  { id:  1, name: "성수연방",          category: "카페",   rating: 4.7, reviews: 2341, district: "성동구", latOffset:  0.002, lngOffset: -0.003 },
-  { id:  2, name: "대림창고",          category: "갤러리", rating: 4.5, reviews: 1823, district: "성동구", latOffset: -0.001, lngOffset:  0.002 },
-  { id:  3, name: "서울숲",            category: "공원",   rating: 4.8, reviews: 5102, district: "성동구", latOffset:  0.004, lngOffset:  0.001 },
-  { id:  4, name: "카페 어니언",       category: "카페",   rating: 4.6, reviews: 3214, district: "성동구", latOffset: -0.002, lngOffset:  0.003 },
-  { id:  5, name: "하이브 사옥",       category: "명소",   rating: 4.9, reviews: 8821, district: "용산구", latOffset:  0.006, lngOffset: -0.004 },
-  { id:  6, name: "경리단길",          category: "거리",   rating: 4.3, reviews: 2109, district: "용산구", latOffset: -0.005, lngOffset:  0.005 },
-  { id:  7, name: "SM 엔터테인먼트",   category: "명소",   rating: 4.7, reviews: 6432, district: "강남구", latOffset:  0.008, lngOffset:  0.006 },
-  { id:  8, name: "별마당도서관",      category: "문화",   rating: 4.6, reviews: 4521, district: "강남구", latOffset: -0.007, lngOffset: -0.002 },
-  { id:  9, name: "광화문 광장",       category: "명소",   rating: 4.7, reviews: 6230, district: "종로구", latOffset:  0.003, lngOffset: -0.006 },
-  { id: 10, name: "홍대 걷고싶은거리", category: "거리",   rating: 4.5, reviews: 8320, district: "마포구", latOffset: -0.004, lngOffset:  0.007 },
-  { id: 11, name: "연남동 카페거리",   category: "카페",   rating: 4.5, reviews: 3412, district: "마포구", latOffset:  0.001, lngOffset: -0.005 },
-  { id: 12, name: "남산타워",          category: "명소",   rating: 4.6, reviews: 9103, district: "용산구", latOffset:  0.005, lngOffset:  0.004 },
-];
-
-// ═══════════════════════════════════════════════════════════
-// HOOKS
+// useUserLocation
 // ═══════════════════════════════════════════════════════════
 
 const useUserLocation = (): UserLocation => {
@@ -150,28 +121,14 @@ const useUserLocation = (): UserLocation => {
   const [lng,        setLng]        = useState<number>(DEFAULT_LNG);
   const [isLocating, setIsLocating] = useState<boolean>(true);
   const [locLabel,   setLocLabel]   = useState<string>("📍 위치 불러오는 중...");
-
   useEffect(() => {
-    if (!navigator.geolocation) {
-      setIsLocating(false);
-      setLocLabel("📍 위치 미지원 (기본 위치 사용)");
-      return;
-    }
+    if (!navigator.geolocation) { setIsLocating(false); setLocLabel("📍 위치 미지원 (기본 위치 사용)"); return; }
     navigator.geolocation.getCurrentPosition(
-      pos => {
-        setLat(pos.coords.latitude);
-        setLng(pos.coords.longitude);
-        setIsLocating(false);
-        setLocLabel("📍 현위치 기준");
-      },
-      () => {
-        setIsLocating(false);
-        setLocLabel("📍 위치 권한 거부됨 (기본 위치 사용)");
-      },
+      pos => { setLat(pos.coords.latitude); setLng(pos.coords.longitude); setIsLocating(false); setLocLabel("📍 현위치 기준"); },
+      ()  => { setIsLocating(false); setLocLabel("📍 위치 권한 거부됨 (기본 위치 사용)"); },
       { timeout: 8000, enableHighAccuracy: true },
     );
   }, []);
-
   return { lat, lng, isLocating, locLabel };
 };
 
@@ -182,84 +139,72 @@ const useUserLocation = (): UserLocation => {
 type SheetState = "hidden" | "half" | "full";
 
 const RouteScreen: FC = () => {
-  // ── 탭 / 시트 상태
   const [activeTab,  setActiveTab]  = useState<Tab | null>(null);
   const [sheetState, setSheetState] = useState<SheetState>("hidden");
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
-
-  // ── 검색창 상태
   const [searchQuery, setSearchQuery] = useState<string>("");
+  const [googleUser,  setGoogleUser]  = useState<GoogleUserProfile | null>(null);
 
-  // ── Google 로그인 상태
-  const [googleUser, setGoogleUser] = useState<GoogleUserProfile | null>(null);
-
-  // ── 주변 탐색 상태
   const [selectedRadiusIdx, setSelectedRadiusIdx] = useState<number>(1);
   const [selectedPlace,     setSelectedPlace]     = useState<Place | null>(null);
 
-  // ── 경로 탐색 상태
   const [routeState, setRouteState] = useState<RouteState>({
     origin: null, destination: null, result: null, isLoading: false, errorMsg: "",
   });
 
-  // ── 지도 / 위치
   const kakaoMapRef    = useRef<KakaoMapInstance | null>(null);
   const mapElRef       = useRef<HTMLDivElement>(null);
   const userOverlayRef = useRef<KakaoOverlay | null>(null);
-  const [isMapReady, setIsMapReady] = useState<boolean>(false);
+  const [isMapReady,      setIsMapReady]      = useState<boolean>(false);
+  const [isServicesReady, setIsServicesReady] = useState<boolean>(false);
+
+  // 공유 지도 레이어 ref
+  const polylineListRef = useRef<KakaoPolyline[]>([]);
+  const overlayListRef  = useRef<KakaoOverlay[]>([]);
 
   const { lat: userLat, lng: userLng, isLocating, locLabel } = useUserLocation();
-
-  // ── 바텀 시트 드래그
   const dragStartYRef = useRef<number>(0);
   const isDraggingRef = useRef<boolean>(false);
   const sheetElRef    = useRef<HTMLDivElement>(null);
+  const radiusConfig  = RADIUS_OPTION_LIST[selectedRadiusIdx];
 
-  // [API] Google 로그인 — access token으로 userinfo 엔드포인트 호출
+  // 주변 탐색
+  const { placeList: kakaoPlaceList, isLoading: kakaoIsLoading, error: kakaoError, refetch: kakaoRefetch } =
+    useKakaoNearby({ userLat, userLng, radiusMeter: radiusConfig.meter, enabled: activeTab === "nearby" && !isLocating && isServicesReady });
+
+  // [CHANGED] 추천 경로 — route 탭이 열릴 때 활성화
+  const { routes: recRoutes, isLoading: recIsLoading, error: recError, refetch: recRefetch } =
+    useRecommendedRoute({ userLat, userLng, enabled: activeTab === "route" && !isLocating && isServicesReady });
+
   const handleGoogleLogin = useGoogleLogin({
     onSuccess: async tokenRes => {
       try {
-        const res = await fetch("https://www.googleapis.com/oauth2/v3/userinfo", {
-          headers: { Authorization: `Bearer ${tokenRes.access_token}` },
-        });
+        const res  = await fetch("https://www.googleapis.com/oauth2/v3/userinfo", { headers: { Authorization: `Bearer ${tokenRes.access_token}` } });
         const data = await res.json();
         setGoogleUser({ name: data.name, email: data.email, picture: data.picture });
-      } catch {
-        console.error("Google 유저 정보 조회 실패");
-      }
+      } catch { console.error("Google 유저 정보 조회 실패"); }
     },
     onError: () => console.error("Google 로그인 실패"),
   });
+  const handleGoogleLogout = useCallback(() => setGoogleUser(null), []);
 
-  // [HANDLER] Google 로그아웃
-  const handleGoogleLogout = useCallback(() => {
-    setGoogleUser(null);
-  }, []);
-
-  // [INIT] 카카오맵 인스턴스 생성 — 마운트 1회
   useEffect(() => {
     if (!window.kakao?.maps || !mapElRef.current) return;
     window.kakao.maps.load(() => {
       const map = new window.kakao.maps.Map(mapElRef.current!, {
-        center: new window.kakao.maps.LatLng(DEFAULT_LAT, DEFAULT_LNG),
-        level:  4,
+        center: new window.kakao.maps.LatLng(DEFAULT_LAT, DEFAULT_LNG), level: 4,
       });
       kakaoMapRef.current = map;
       setIsMapReady(true);
+      setIsServicesReady(true);
     });
   }, []);
 
-  // [SYNC] 현위치 마커 — 탭 무관하게 항상 표시
   useEffect(() => {
     if (!isMapReady || isLocating || !kakaoMapRef.current) return;
     userOverlayRef.current?.setMap(null);
     const el = document.createElement("div");
-    el.style.cssText = `
-      width:14px; height:14px; border-radius:50%;
-      background:${COLOR_USER_PIN};
-      border:3px solid #fff;
-      box-shadow:0 0 0 5px ${COLOR_USER_PIN_RING};
-    `;
+    el.style.cssText = `width:14px;height:14px;border-radius:50%;background:${COLOR_USER_PIN};border:3px solid #fff;box-shadow:0 0 0 5px ${COLOR_USER_PIN_RING};`;
     userOverlayRef.current = new window.kakao.maps.CustomOverlay({
       map: kakaoMapRef.current, position: new window.kakao.maps.LatLng(userLat, userLng),
       content: el, yAnchor: 0.5, zIndex: 20,
@@ -267,338 +212,184 @@ const RouteScreen: FC = () => {
     kakaoMapRef.current.setCenter(new window.kakao.maps.LatLng(userLat, userLng));
   }, [isMapReady, isLocating, userLat, userLng]);
 
-  // [SYNC] 장소 선택 시 지도 중심 이동
   useEffect(() => {
     if (!selectedPlace || !kakaoMapRef.current || !isMapReady) return;
-    kakaoMapRef.current.setCenter(
-      new window.kakao.maps.LatLng(selectedPlace.lat, selectedPlace.lng)
-    );
+    kakaoMapRef.current.setCenter(new window.kakao.maps.LatLng(selectedPlace.lat, selectedPlace.lng));
   }, [selectedPlace, isMapReady]);
 
-  // [HANDLER] 현위치로 지도 이동
+  const clearMapLayers = useCallback(() => {
+    polylineListRef.current.forEach(p => p.setMap(null));
+    overlayListRef.current.forEach(o => o.setMap(null));
+    polylineListRef.current = []; overlayListRef.current = [];
+  }, []);
+
   const handleMoveToCurrentLoc = useCallback(() => {
     if (!kakaoMapRef.current || !isMapReady) return;
     kakaoMapRef.current.setCenter(new window.kakao.maps.LatLng(userLat, userLng));
   }, [userLat, userLng, isMapReady]);
 
-  // [HANDLER] FAB 메뉴 항목 선택
   const handleMenuSelect = useCallback((tab: Tab) => {
+    if (tab !== activeTab) clearMapLayers();
     setActiveTab(tab);
     setIsMenuOpen(false);
     setSheetState("half");
-  }, []);
+  }, [activeTab, clearMapLayers]);
 
-  // [HANDLER] 시트 닫기
   const handleCloseSheet = useCallback(() => {
     setSheetState("hidden");
     setTimeout(() => setActiveTab(null), 300);
   }, []);
 
-  // [HANDLER] 드래그 시작
-  const handleDragStart = useCallback((clientY: number) => {
-    isDraggingRef.current = true;
-    dragStartYRef.current = clientY;
-  }, []);
-
-  // [HANDLER] 드래그 종료
-  const handleDragEnd = useCallback((clientY: number) => {
+  const handleDragStart = useCallback((y: number) => { isDraggingRef.current = true; dragStartYRef.current = y; }, []);
+  const handleDragEnd   = useCallback((y: number) => {
     if (!isDraggingRef.current) return;
     isDraggingRef.current = false;
-    const delta = clientY - dragStartYRef.current;
-
+    const delta = y - dragStartYRef.current;
     if (sheetState === "half") {
       if (delta < -DRAG_THRESHOLD) setSheetState("full");
       else if (delta > DRAG_THRESHOLD) handleCloseSheet();
-    } else if (sheetState === "full") {
-      if (delta > DRAG_THRESHOLD) setSheetState("half");
-    }
+    } else if (sheetState === "full" && delta > DRAG_THRESHOLD) setSheetState("half");
   }, [sheetState, handleCloseSheet]);
 
-  // 주변 탐색 데이터
-  const radiusConfig    = RADIUS_OPTION_LIST[selectedRadiusIdx];
-  const activePlaceList = PLACE_LIST
-    .map(p => toPlace(p, userLat, userLng))
-    .filter(p => p.distance <= radiusConfig.meter)
-    .sort((a, b) => a.distance - b.distance);
+  const handleSelectPlace  = (place: Place | null) => setSelectedPlace(prev => prev?.id === place?.id ? null : place);
+  const handleSelectRadius = (idx: number) => { setSelectedRadiusIdx(idx); setSelectedPlace(null); };
+  const handleSetOrigin    = (p: RoutePoint | null) => setRouteState(prev => ({ ...prev, origin: p }));
+  const handleSetDest      = (p: RoutePoint | null) => setRouteState(prev => ({ ...prev, destination: p }));
+  const handleSetResult    = (r: RouteResult | null) => setRouteState(prev => ({ ...prev, result: r }));
+  const handleSetLoading   = (v: boolean) => setRouteState(prev => ({ ...prev, isLoading: v }));
+  const handleSetError     = (m: string)  => setRouteState(prev => ({ ...prev, errorMsg: m }));
 
-  // 핸들러 모음
-  const handleSelectPlace    = (place: Place | null) =>
-    setSelectedPlace(prev => prev?.id === place?.id ? null : place);
-  const handleSelectRadius   = (idx: number) => { setSelectedRadiusIdx(idx); setSelectedPlace(null); };
-  const handleSetOrigin      = (point: RoutePoint | null) => setRouteState(prev => ({ ...prev, origin: point }));
-  const handleSetDest        = (point: RoutePoint | null) => setRouteState(prev => ({ ...prev, destination: point }));
-  const handleSetRouteResult = (result: RouteResult | null) => setRouteState(prev => ({ ...prev, result }));
-  const handleSetLoading     = (isLoading: boolean) => setRouteState(prev => ({ ...prev, isLoading }));
-  const handleSetError       = (errorMsg: string) => setRouteState(prev => ({ ...prev, errorMsg }));
-
-  const sheetHeightVh =
-    sheetState === "full" ? SHEET_HEIGHT_FULL :
-    sheetState === "half" ? SHEET_HEIGHT_HALF : 0;
+  const sheetHeightVh = sheetState === "full" ? SHEET_HEIGHT_FULL : sheetState === "half" ? SHEET_HEIGHT_HALF : 0;
 
   return (
     <div style={{ position: "fixed", inset: 0, fontFamily: "'Noto Sans KR', sans-serif", background: "#000" }}>
-
-      {/* ── 지도 (풀스크린 고정) */}
       <div ref={mapElRef} style={{ position: "absolute", inset: 0 }} />
 
-      {/* ── 검색창 */}
-      <div style={{
-        position: "absolute", top: 16, left: 16, right: 16, zIndex: 30,
-        background: "rgba(255,255,255,0.96)", backdropFilter: "blur(10px)",
-        borderRadius: 14, boxShadow: "0 2px 16px rgba(0,0,0,0.12)",
-        display: "flex", alignItems: "center", gap: 10, padding: "10px 14px",
-      }}>
-        {/* 돋보기 */}
+      {/* 검색창 */}
+      <div style={{ position: "absolute", top: 16, left: 16, right: 16, zIndex: 30, background: "rgba(255,255,255,0.96)", backdropFilter: "blur(10px)", borderRadius: 14, boxShadow: "0 2px 16px rgba(0,0,0,0.12)", display: "flex", alignItems: "center", gap: 10, padding: "10px 14px" }}>
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={COLOR_TEXT_SUB} strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}>
-          <circle cx="11" cy="11" r="7" />
-          <line x1="16.5" y1="16.5" x2="22" y2="22" />
+          <circle cx="11" cy="11" r="7" /><line x1="16.5" y1="16.5" x2="22" y2="22" />
         </svg>
-
-        {/* 입력창 */}
-        <input
-          type="text"
-          value={searchQuery}
-          onChange={e => setSearchQuery(e.target.value)}
-          placeholder="장소, 주소를 검색하세요"
-          style={{
-            flex: 1, border: "none", outline: "none",
-            fontSize: 14, color: COLOR_TEXT_MAIN,
-            background: "transparent", fontFamily: "'Noto Sans KR', sans-serif",
-          }}
-        />
-
-        {/* 입력 초기화 */}
+        <input type="text" value={searchQuery} onChange={e => setSearchQuery(e.target.value)} placeholder="장소, 주소를 검색하세요" style={{ flex: 1, border: "none", outline: "none", fontSize: 14, color: COLOR_TEXT_MAIN, background: "transparent", fontFamily: "'Noto Sans KR', sans-serif" }} />
         {searchQuery.length > 0 && (
-          <div
-            onClick={() => setSearchQuery("")}
-            style={{
-              width: 20, height: 20, borderRadius: "50%",
-              background: COLOR_INACTIVE, flexShrink: 0,
-              display: "flex", alignItems: "center", justifyContent: "center",
-              cursor: "pointer", fontSize: 11, color: "#fff", fontWeight: 700,
-            }}
-          >✕</div>
+          <div onClick={() => setSearchQuery("")} style={{ width: 20, height: 20, borderRadius: "50%", background: COLOR_INACTIVE, flexShrink: 0, display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", fontSize: 11, color: "#fff", fontWeight: 700 }}>✕</div>
         )}
-
         <div style={{ width: 1, height: 18, background: COLOR_BORDER, flexShrink: 0 }} />
-
-        {/* Google 로그인 버튼 */}
-        <div
-          onClick={() => googleUser ? handleGoogleLogout() : handleGoogleLogin()}
-          title={googleUser ? `${googleUser.name} (로그아웃)` : "Google 로그인"}
-          style={{
-            width: 32, height: 32, borderRadius: "50%",
-            background: googleUser ? COLOR_BG : "#fff",
-            border: `1px solid ${COLOR_BORDER}`,
-            display: "flex", alignItems: "center", justifyContent: "center",
-            cursor: "pointer", flexShrink: 0,
-            overflow: "hidden", transition: "all 0.2s",
-          }}
-        >
-          {googleUser
-            ? <img src={googleUser.picture} alt={googleUser.name} style={{ width: "100%", height: "100%", objectFit: "cover", borderRadius: "50%" }} />
-            : <IconGoogle />
-          }
+        <div onClick={() => googleUser ? handleGoogleLogout() : handleGoogleLogin()} style={{ width: 32, height: 32, borderRadius: "50%", background: googleUser ? COLOR_BG : "#fff", border: `1px solid ${COLOR_BORDER}`, display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", flexShrink: 0, overflow: "hidden" }}>
+          {googleUser ? <img src={googleUser.picture} alt={googleUser.name} style={{ width: "100%", height: "100%", objectFit: "cover", borderRadius: "50%" }} /> : <IconGoogle />}
         </div>
-
-        {/* 현위치 버튼 */}
-        <div
-          onClick={handleMoveToCurrentLoc}
-          title="현재 위치로 이동"
-          style={{
-            width: 32, height: 32, borderRadius: "50%",
-            background: isLocating ? COLOR_BG : `${COLOR_USER_PIN}18`,
-            border: `1px solid ${isLocating ? COLOR_BORDER : COLOR_USER_PIN}`,
-            display: "flex", alignItems: "center", justifyContent: "center",
-            cursor: isLocating ? "default" : "pointer",
-            flexShrink: 0, transition: "all 0.2s",
-          }}
-        >
+        <div onClick={handleMoveToCurrentLoc} style={{ width: 32, height: 32, borderRadius: "50%", background: isLocating ? COLOR_BG : `${COLOR_USER_PIN}18`, border: `1px solid ${isLocating ? COLOR_BORDER : COLOR_USER_PIN}`, display: "flex", alignItems: "center", justifyContent: "center", cursor: isLocating ? "default" : "pointer", flexShrink: 0 }}>
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke={isLocating ? COLOR_TEXT_SUB : COLOR_USER_PIN} strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
-            <circle cx="12" cy="12" r="3" />
-            <path d="M12 2v3M12 19v3M2 12h3M19 12h3" />
-            <circle cx="12" cy="12" r="8" strokeOpacity="0.25" />
+            <circle cx="12" cy="12" r="3" /><path d="M12 2v3M12 19v3M2 12h3M19 12h3" /><circle cx="12" cy="12" r="8" strokeOpacity="0.25" />
           </svg>
         </div>
       </div>
 
-      {/* ── 지도 위 오버레이 레이어 */}
+      {/* 지도 오버레이 */}
       {activeTab === "nearby" && (
         <NearbyMap
           userLat={userLat} userLng={userLng} isLocating={isLocating} locLabel={locLabel}
           radiusMeter={radiusConfig.meter} selectedPlace={selectedPlace} onSelectPlace={handleSelectPlace}
           selectedRadiusIdx={selectedRadiusIdx} onSelectRadius={handleSelectRadius}
-          kakaoMapRef={kakaoMapRef} isMapReady={isMapReady}
+          kakaoMapRef={kakaoMapRef} isMapReady={isMapReady} placeList={kakaoPlaceList}
         />
       )}
-      {activeTab === "route" && (
-        <RouteMap routeState={routeState} kakaoMapRef={kakaoMapRef} isMapReady={isMapReady} />
-      )}
 
-      {/* ── 시트 열렸을 때 지도 딤 처리 */}
       {sheetState !== "hidden" && (
-        <div
-          onClick={handleCloseSheet}
-          style={{
-            position: "absolute", inset: 0,
-            background: "rgba(0,0,0,0.08)",
-            transition: "opacity 0.3s", pointerEvents: "auto",
-          }}
-        />
+        <div onClick={handleCloseSheet} style={{ position: "absolute", inset: 0, background: "rgba(0,0,0,0.08)", pointerEvents: "auto" }} />
       )}
 
-      {/* ── FAB 메뉴 */}
+      {/* FAB */}
       <div style={{ position: "absolute", bottom: 32, right: 20, display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 12, zIndex: 50 }}>
         {MENU_ITEM_LIST.map((item, i) => (
-          <div
-            key={item.id}
-            onClick={() => handleMenuSelect(item.id)}
-            style={{
-              display: "flex", alignItems: "center", gap: 10,
-              opacity:       isMenuOpen ? 1 : 0,
-              transform:     isMenuOpen ? "translateY(0) scale(1)" : "translateY(16px) scale(0.85)",
-              transition:    `opacity 0.22s ease ${i * 0.06}s, transform 0.22s ease ${i * 0.06}s`,
-              pointerEvents: isMenuOpen ? "auto" : "none",
-              cursor:        "pointer",
-            }}
-          >
-            <div style={{
-              background: "rgba(255,255,255,0.97)", backdropFilter: "blur(8px)",
-              borderRadius: 10, padding: "6px 12px",
-              fontSize: 13, fontWeight: 700, color: COLOR_TEXT_MAIN,
-              boxShadow: "0 2px 12px rgba(0,0,0,0.12)", whiteSpace: "nowrap",
-            }}>
-              {item.label}
-            </div>
-            <div style={{
-              width: 46, height: 46, borderRadius: "50%",
-              background: COLOR_PRIMARY,
-              display: "flex", alignItems: "center", justifyContent: "center",
-              boxShadow: "0 3px 14px rgba(0,0,0,0.18)", flexShrink: 0,
-            }}>
-              <item.Icon />
-            </div>
+          <div key={item.id} onClick={() => handleMenuSelect(item.id)} style={{ display: "flex", alignItems: "center", gap: 10, opacity: isMenuOpen ? 1 : 0, transform: isMenuOpen ? "translateY(0) scale(1)" : "translateY(16px) scale(0.85)", transition: `opacity 0.22s ease ${i * 0.06}s, transform 0.22s ease ${i * 0.06}s`, pointerEvents: isMenuOpen ? "auto" : "none", cursor: "pointer" }}>
+            <div style={{ background: "rgba(255,255,255,0.97)", backdropFilter: "blur(8px)", borderRadius: 10, padding: "6px 12px", fontSize: 13, fontWeight: 700, color: COLOR_TEXT_MAIN, boxShadow: "0 2px 12px rgba(0,0,0,0.12)", whiteSpace: "nowrap" }}>{item.label}</div>
+            <div style={{ width: 46, height: 46, borderRadius: "50%", background: COLOR_PRIMARY, display: "flex", alignItems: "center", justifyContent: "center", boxShadow: "0 3px 14px rgba(0,0,0,0.18)", flexShrink: 0 }}><item.Icon /></div>
           </div>
         ))}
-
-        <div
-          onClick={() => setIsMenuOpen(prev => !prev)}
-          style={{
-            width: 56, height: 56, borderRadius: "50%",
-            background: COLOR_PRIMARY,
-            display: "flex", alignItems: "center", justifyContent: "center",
-            boxShadow: "0 4px 20px rgba(245,154,0,0.45)",
-            cursor: "pointer", transition: "transform 0.25s ease",
-            transform: isMenuOpen ? "rotate(45deg)" : "rotate(0deg)",
-            zIndex: 51,
-          }}
-        >
+        <div onClick={() => setIsMenuOpen(prev => !prev)} style={{ width: 56, height: 56, borderRadius: "50%", background: COLOR_PRIMARY, display: "flex", alignItems: "center", justifyContent: "center", boxShadow: "0 4px 20px rgba(245,154,0,0.45)", cursor: "pointer", transition: "transform 0.25s ease", transform: isMenuOpen ? "rotate(45deg)" : "rotate(0deg)", zIndex: 51 }}>
           <span style={{ fontSize: 26, color: "#fff", lineHeight: 1, fontWeight: 300 }}>+</span>
         </div>
       </div>
 
-      {/* ── 하프 바텀 시트 */}
-      <div
-        ref={sheetElRef}
-        style={{
-          position: "absolute", left: 0, right: 0, bottom: 0,
-          height: `${sheetHeightVh}vh`,
-          background: COLOR_SURFACE, borderRadius: "20px 20px 0 0",
-          boxShadow: "0 -4px 32px rgba(0,0,0,0.14)",
-          transition: isDraggingRef.current ? "none" : "height 0.32s cubic-bezier(0.32,0.72,0,1)",
-          zIndex: 40, display: "flex", flexDirection: "column", overflow: "hidden",
-        }}
-      >
-        {/* 드래그 핸들 */}
-        <div
-          onTouchStart={e => handleDragStart(e.touches[0].clientY)}
-          onTouchEnd={e => handleDragEnd(e.changedTouches[0].clientY)}
-          onMouseDown={e => handleDragStart(e.clientY)}
-          onMouseUp={e => handleDragEnd(e.clientY)}
-          style={{ padding: "12px 0 8px", flexShrink: 0, cursor: "grab", userSelect: "none" }}
-        >
+      {/* 바텀 시트 */}
+      <div ref={sheetElRef} style={{ position: "absolute", left: 0, right: 0, bottom: 0, height: `${sheetHeightVh}vh`, background: COLOR_SURFACE, borderRadius: "20px 20px 0 0", boxShadow: "0 -4px 32px rgba(0,0,0,0.14)", transition: isDraggingRef.current ? "none" : "height 0.32s cubic-bezier(0.32,0.72,0,1)", zIndex: 40, display: "flex", flexDirection: "column", overflow: "hidden" }}>
+
+        <div onTouchStart={e => handleDragStart(e.touches[0].clientY)} onTouchEnd={e => handleDragEnd(e.changedTouches[0].clientY)} onMouseDown={e => handleDragStart(e.clientY)} onMouseUp={e => handleDragEnd(e.clientY)} style={{ padding: "12px 0 8px", flexShrink: 0, cursor: "grab", userSelect: "none" }}>
           <div style={{ width: 36, height: 4, borderRadius: 2, background: COLOR_BORDER, margin: "0 auto" }} />
         </div>
 
-        {/* 시트 헤더 */}
         {activeTab && (
-          <div style={{
-            padding: "4px 20px 12px",
-            display: "flex", justifyContent: "space-between", alignItems: "center",
-            flexShrink: 0, borderBottom: `1px solid ${COLOR_BORDER}`,
-          }}>
+          <div style={{ padding: "4px 20px 12px", display: "flex", justifyContent: "space-between", alignItems: "center", flexShrink: 0, borderBottom: `1px solid ${COLOR_BORDER}` }}>
             <div>
-              <div style={{ fontSize: 11, color: COLOR_TEXT_SUB, letterSpacing: 2, fontWeight: 600 }}>
-                {activeTab === "nearby" ? "NEARBY EXPLORE" : "ROUTE PLANNING"}
-              </div>
-              <div style={{ fontSize: 17, fontWeight: 900, color: COLOR_TEXT_MAIN, marginTop: 2 }}>
-                {activeTab === "nearby" ? "근처 인기 장소 탐색" : "경로 탐색"}
-              </div>
+              <div style={{ fontSize: 11, color: COLOR_TEXT_SUB, letterSpacing: 2, fontWeight: 600 }}>{TAB_HEADER[activeTab]?.sub}</div>
+              <div style={{ fontSize: 17, fontWeight: 900, color: COLOR_TEXT_MAIN, marginTop: 2 }}>{TAB_HEADER[activeTab]?.main}</div>
             </div>
-            <div
-              onClick={handleCloseSheet}
-              style={{
-                width: 32, height: 32, borderRadius: "50%",
-                background: COLOR_BG, border: `1px solid ${COLOR_BORDER}`,
-                display: "flex", alignItems: "center", justifyContent: "center",
-                cursor: "pointer", fontSize: 16, color: COLOR_TEXT_SUB,
-              }}
-            >✕</div>
+            <div onClick={handleCloseSheet} style={{ width: 32, height: 32, borderRadius: "50%", background: COLOR_BG, border: `1px solid ${COLOR_BORDER}`, display: "flex", alignItems: "center", justifyContent: "center", cursor: "pointer", fontSize: 16, color: COLOR_TEXT_SUB }}>✕</div>
           </div>
         )}
 
-        {/* 시트 콘텐츠 */}
         <div style={{ flex: 1, overflowY: "auto" }}>
+
+          {/* 주변 탐색 */}
           {activeTab === "nearby" && (
             <div style={{ padding: "12px 16px 24px" }}>
               <div style={{ display: "flex", gap: 6, marginBottom: 14 }}>
                 {RADIUS_OPTION_LIST.map((opt, i) => (
-                  <button
-                    key={opt.label}
-                    onClick={() => handleSelectRadius(i)}
-                    style={{
-                      flex: 1, padding: "7px 0", borderRadius: 10,
-                      border:     `1.5px solid ${selectedRadiusIdx === i ? COLOR_PRIMARY : COLOR_BORDER}`,
-                      background: selectedRadiusIdx === i ? COLOR_PRIMARY : COLOR_SURFACE,
-                      color:      selectedRadiusIdx === i ? "#fff" : COLOR_TEXT_SUB,
-                      fontSize: 12, fontWeight: 700, cursor: "pointer",
-                      fontFamily: "'Noto Sans KR', sans-serif", transition: "all 0.18s",
-                    }}
-                  >
+                  <button key={opt.label} onClick={() => handleSelectRadius(i)} style={{ flex: 1, padding: "7px 0", borderRadius: 10, border: `1.5px solid ${selectedRadiusIdx === i ? COLOR_PRIMARY : COLOR_BORDER}`, background: selectedRadiusIdx === i ? COLOR_PRIMARY : COLOR_SURFACE, color: selectedRadiusIdx === i ? "#fff" : COLOR_TEXT_SUB, fontSize: 12, fontWeight: 700, cursor: "pointer", fontFamily: "'Noto Sans KR', sans-serif", transition: "all 0.18s" }}>
                     {opt.label}
-                    <div style={{ fontSize: 10, fontWeight: 400, marginTop: 1, opacity: 0.8 }}>
-                      {opt.meter >= 1000 ? `${opt.meter / 1000}km` : `${opt.meter}m`}
-                    </div>
+                    <div style={{ fontSize: 10, fontWeight: 400, marginTop: 1, opacity: 0.8 }}>{opt.meter >= 1000 ? `${opt.meter / 1000}km` : `${opt.meter}m`}</div>
                   </button>
                 ))}
               </div>
-
-              <div style={{ fontSize: 13, fontWeight: 700, color: COLOR_TEXT_SUB, marginBottom: 10, display: "flex", alignItems: "center", gap: 8 }}>
-                <span>주변 장소 <span style={{ color: COLOR_PRIMARY }}>{activePlaceList.length}</span></span>
-                <span style={{ fontWeight: 400, fontSize: 11 }}>거리순</span>
-              </div>
-
-              {activePlaceList.length === 0
-                ? <div style={{ textAlign: "center", color: COLOR_INACTIVE, fontSize: 13, padding: 32 }}>반경 내 장소가 없어요</div>
-                : <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                    {activePlaceList.map(place => (
-                      <PlaceCard
-                        key={place.id} place={place}
-                        isSelected={selectedPlace?.id === place.id}
-                        onSelect={handleSelectPlace}
-                      />
-                    ))}
+              {kakaoIsLoading && (
+                <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 10, padding: "32px 0", color: COLOR_TEXT_SUB }}>
+                  <div style={{ width: 28, height: 28, border: `3px solid ${COLOR_PRIMARY}`, borderTopColor: "transparent", borderRadius: "50%", animation: "spin 0.8s linear infinite" }} />
+                  <span style={{ fontSize: 13 }}>주변 장소를 불러오는 중...</span>
+                  <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+                </div>
+              )}
+              {!kakaoIsLoading && kakaoError && (
+                <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 10, padding: "32px 0" }}>
+                  <span style={{ fontSize: 28 }}>⚠️</span>
+                  <span style={{ fontSize: 13, color: "#e53e3e", textAlign: "center" }}>{kakaoError}</span>
+                  <button onClick={kakaoRefetch} style={{ padding: "8px 18px", borderRadius: 10, border: `1.5px solid ${COLOR_PRIMARY}`, background: "transparent", color: COLOR_PRIMARY, fontSize: 13, fontWeight: 700, cursor: "pointer", fontFamily: "'Noto Sans KR', sans-serif" }}>다시 시도</button>
+                </div>
+              )}
+              {!kakaoIsLoading && !kakaoError && (
+                <>
+                  <div style={{ fontSize: 13, fontWeight: 700, color: COLOR_TEXT_SUB, marginBottom: 10, display: "flex", alignItems: "center", gap: 8 }}>
+                    <span>주변 장소 <span style={{ color: COLOR_PRIMARY }}>{kakaoPlaceList.length}</span></span>
+                    <span style={{ fontWeight: 400, fontSize: 11 }}>거리순</span>
+                    <button onClick={kakaoRefetch} style={{ marginLeft: "auto", background: "none", border: "none", cursor: "pointer", fontSize: 16, color: COLOR_TEXT_SUB, padding: 0 }}>🔄</button>
                   </div>
-              }
+                  {kakaoPlaceList.length === 0
+                    ? <div style={{ textAlign: "center", color: COLOR_INACTIVE, fontSize: 13, padding: 32 }}>반경 내 장소가 없어요</div>
+                    : <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                        {kakaoPlaceList.map(place => (
+                          <PlaceCard key={place.id} place={place} isSelected={selectedPlace?.id === place.id} onSelect={handleSelectPlace} />
+                        ))}
+                      </div>
+                  }
+                </>
+              )}
             </div>
           )}
 
+          {/* [CHANGED] 경로 탐색 탭 — 추천 경로 + 직접 입력 통합 */}
           {activeTab === "route" && (
             <RoutePanel
               routeState={routeState}
               onSetOrigin={handleSetOrigin} onSetDest={handleSetDest}
-              onSetResult={handleSetRouteResult} onSetLoading={handleSetLoading} onSetError={handleSetError}
+              onSetResult={handleSetResult} onSetLoading={handleSetLoading} onSetError={handleSetError}
               userLat={userLat} userLng={userLng}
+              kakaoMapRef={kakaoMapRef}
+              polylineListRef={polylineListRef}
+              overlayListRef={overlayListRef}
+              recRoutes={recRoutes}
+              recIsLoading={recIsLoading}
+              recError={recError}
+              recRefetch={recRefetch}
             />
           )}
         </div>

--- a/Route_Planning/src/hooks/Usekakaonearby.ts
+++ b/Route_Planning/src/hooks/Usekakaonearby.ts
@@ -1,0 +1,268 @@
+// ═══════════════════════════════════════════════════════════
+// useKakaoNearby — 카카오맵 Places + Tripadvisor Reviews 혼합 훅
+//
+// [흐름]
+//   1. 카카오 categorySearch → 주변 장소 목록 (이름·좌표·거리)
+//   2. 장소명으로 Tripadvisor Location Search → location_id
+//   3. location_id로 Tripadvisor Details → rating·num_reviews
+//   4. 카카오 Place에 평점 병합 후 반환
+//
+// [환경변수]
+//   VITE_TRIPADVISOR_API_KEY=your_key
+//
+// [CORS] Vite 프록시 사용 (vite.config.ts 설정 필요)
+//   "/vite-proxy/tripadvisor" → "https://api.content.tripadvisor.com"
+// ═══════════════════════════════════════════════════════════
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import type { Place, Category } from "../types/type";
+
+// ── [CONFIG] ──────────────────────────────────────────────
+
+const TA_API_KEY = import.meta.env.VITE_TRIPADVISOR_API_KEY as string;
+
+const KAKAO_CATEGORY_LIST: { code: string; category: Category }[] = [
+  { code: "AT4", category: "명소" },   // 관광명소
+  { code: "CT1", category: "문화" },   // 문화시설
+  { code: "CE7", category: "카페" },   // 카페
+];
+
+// ── [TYPES] ───────────────────────────────────────────────
+
+interface KakaoPlaceItem {
+  id:                  string;
+  place_name:          string;
+  category_group_code: string;
+  address_name:        string;
+  x:                   string;   // 경도
+  y:                   string;   // 위도
+  distance:            string;   // 미터
+}
+
+interface TaSearchResponse {
+  data?:  { location_id: string; name: string }[];
+  error?: { message: string };
+}
+
+interface TaDetailResponse {
+  rating?:      string;
+  num_reviews?: string;
+  error?:       { message: string };
+}
+
+// ── [UTIL] ────────────────────────────────────────────────
+
+// Vite 프록시 경유 URL 생성
+const taUrl = (path: string) =>
+  import.meta.env.DEV
+    ? `/vite-proxy/tripadvisor/v1/${path}`
+    : `${import.meta.env.VITE_BACKEND_URL}/api/tripadvisor/${path}`;
+
+/**
+ * 장소명 + 좌표로 Tripadvisor location_id 조회
+ * latLong 힌트를 함께 보내 정확도 향상
+ */
+const fetchTaLocationId = async (
+  placeName: string,
+  lat:       number,
+  lng:       number,
+): Promise<string | null> => {
+  try {
+    const params = new URLSearchParams({
+      searchQuery: placeName,
+      latLong:     `${lat},${lng}`,
+      language:    "ko",
+      key:         TA_API_KEY,
+    });
+    const res  = await fetch(`${taUrl("location/search")}?${params}`);
+    if (!res.ok) return null;
+    const json: TaSearchResponse = await res.json();
+    return json.data?.[0]?.location_id ?? null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * location_id로 Tripadvisor Details에서 평점·리뷰 수 조회
+ */
+const fetchTaDetail = async (
+  locationId: string,
+): Promise<{ rating: number; reviews: number } | null> => {
+  try {
+    const params = new URLSearchParams({ language: "ko", key: TA_API_KEY });
+    const res    = await fetch(`${taUrl(`location/${locationId}/details`)}?${params}`);
+    if (!res.ok) return null;
+    const json: TaDetailResponse = await res.json();
+    return {
+      rating:  parseFloat(json.rating      ?? "0"),
+      reviews: parseInt(json.num_reviews   ?? "0", 10),
+    };
+  } catch {
+    return null;
+  }
+};
+
+// ── [HOOK] ────────────────────────────────────────────────
+
+interface UseKakaoNearbyOptions {
+  userLat:     number;
+  userLng:     number;
+  radiusMeter: number;
+  enabled:     boolean;
+}
+
+interface UseKakaoNearbyResult {
+  placeList:  Place[];
+  isLoading:  boolean;
+  error:      string | null;
+  refetch:    () => void;
+}
+
+export const useKakaoNearby = ({
+  userLat,
+  userLng,
+  radiusMeter,
+  enabled,
+}: UseKakaoNearbyOptions): UseKakaoNearbyResult => {
+  const [placeList, setPlaceList] = useState<Place[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error,     setError]     = useState<string | null>(null);
+  const [fetchKey,  setFetchKey]  = useState<number>(0);
+
+  const cancelledRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (!window.kakao?.maps?.services) {
+      setError("카카오맵 서비스가 준비되지 않았습니다");
+      return;
+    }
+
+    // 세션 캐시 확인
+    const cacheKey = `kakao_nearby_${userLat.toFixed(4)}_${userLng.toFixed(4)}_${radiusMeter}`;
+    const cached   = sessionStorage.getItem(cacheKey);
+    if (cached) {
+      try {
+        setPlaceList(JSON.parse(cached));
+        return;
+      } catch {
+        sessionStorage.removeItem(cacheKey);
+      }
+    }
+
+    cancelledRef.current = false;
+    setIsLoading(true);
+    setError(null);
+    setPlaceList([]);
+
+    const ps     = new (window.kakao.maps.services as any).Places();
+    const center = new window.kakao.maps.LatLng(userLat, userLng);
+
+    // ── Step 1: 카카오 카테고리 검색 (병렬)
+    let completed = 0;
+    const rawPlaces: { item: KakaoPlaceItem; category: Category }[] = [];
+    const seenIds  = new Set<string>();
+
+    KAKAO_CATEGORY_LIST.forEach(({ code, category }) => {
+      ps.categorySearch(
+        code,
+        (result: KakaoPlaceItem[], status: string) => {
+          completed++;
+
+          if (!cancelledRef.current) {
+            if (status === (window.kakao.maps.services as any).Status.OK) {
+              result.forEach(item => {
+                const dist = parseInt(item.distance, 10);
+                if (!seenIds.has(item.id) && dist <= radiusMeter) {
+                  seenIds.add(item.id);
+                  rawPlaces.push({ item, category });
+                }
+              });
+            }
+
+            // 모든 카테고리 검색 완료 → Step 2
+            if (completed === KAKAO_CATEGORY_LIST.length) {
+              if (rawPlaces.length === 0) {
+                setPlaceList([]);
+                setIsLoading(false);
+                return;
+              }
+              enrichWithTripadvisor(rawPlaces);
+            }
+          }
+        },
+        {
+          location: center,
+          radius:   radiusMeter,
+          sort:     (window.kakao.maps.services as any).SortBy?.DISTANCE ?? "distance",
+        },
+      );
+    });
+
+    // ── Step 2: Tripadvisor로 평점 보강
+    const enrichWithTripadvisor = async (
+      items: { item: KakaoPlaceItem; category: Category }[],
+    ) => {
+      // 거리순 정렬 후 최대 30개 (API 호출 수 제한)
+      items.sort((a, b) => parseInt(a.item.distance) - parseInt(b.item.distance));
+      const top = items.slice(0, 30);
+
+      // location_id 병렬 조회
+      const idResults = await Promise.allSettled(
+        top.map(({ item }) =>
+          fetchTaLocationId(
+            item.place_name,
+            parseFloat(item.y),
+            parseFloat(item.x),
+          )
+        ),
+      );
+
+      if (cancelledRef.current) return;
+
+      // Details 병렬 조회 (location_id 없는 항목은 null)
+      const detailResults = await Promise.allSettled(
+        idResults.map(res =>
+          res.status === "fulfilled" && res.value
+            ? fetchTaDetail(res.value)
+            : Promise.resolve(null)
+        ),
+      );
+
+      if (cancelledRef.current) return;
+
+      // Place 조립
+      const places: Place[] = top.map(({ item, category }, i) => {
+        const detail =
+          detailResults[i].status === "fulfilled" ? detailResults[i].value : null;
+
+        return {
+          id:       parseInt(item.id, 10),
+          name:     item.place_name,
+          category,
+          rating:   detail?.rating  ?? 0,
+          reviews:  detail?.reviews ?? 0,
+          district: item.address_name.split(" ").slice(0, 2).join(" "),
+          lat:      parseFloat(item.y),
+          lng:      parseFloat(item.x),
+          distance: parseInt(item.distance, 10),
+        };
+      });
+
+      sessionStorage.setItem(cacheKey, JSON.stringify(places));
+      setPlaceList(places);
+      setIsLoading(false);
+    };
+
+    return () => { cancelledRef.current = true; };
+  }, [userLat, userLng, radiusMeter, enabled, fetchKey]);
+
+  const refetch = useCallback(() => {
+    const cacheKey = `kakao_nearby_${userLat.toFixed(4)}_${userLng.toFixed(4)}_${radiusMeter}`;
+    sessionStorage.removeItem(cacheKey);
+    setFetchKey(prev => prev + 1);
+  }, [userLat, userLng, radiusMeter]);
+
+  return { placeList, isLoading, error, refetch };
+};

--- a/Route_Planning/src/hooks/Userecommendedroute.ts
+++ b/Route_Planning/src/hooks/Userecommendedroute.ts
@@ -1,0 +1,336 @@
+// ═══════════════════════════════════════════════════════════
+// useRecommendedRoute — 평점 기반 추천 경로 후보 3개 생성 훅
+//
+// [변경] 단일 경로 → 후보 경로 3개 생성
+//   후보 A: 명소·문화 중심 (고평점 우선)
+//   후보 B: 카페·공원 중심 (거리 가중)
+//   후보 C: 카테고리 혼합 (다양성 최대화)
+// ═══════════════════════════════════════════════════════════
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import type { Place, Category, RouteResult, DirectionsResponse } from "../types/type";
+
+// ── [CONFIG] ──────────────────────────────────────────────
+
+const TA_API_KEY    = import.meta.env.VITE_TRIPADVISOR_API_KEY as string;
+const SEARCH_RADIUS = 2000;
+const MAX_WP = 5;
+
+const CATEGORY_WEIGHT: Record<Category, number> = {
+  명소: 1.4, 문화: 1.3, 공원: 1.2, 카페: 1.1, 갤러리: 1.1, 거리: 1.0,
+};
+
+const ALL_KAKAO_CATS: { code: string; category: Category }[] = [
+  { code: "AT4", category: "명소" },
+  { code: "CT1", category: "문화" },
+  { code: "CE7", category: "카페" },
+  { code: "PK6", category: "공원" },
+];
+
+// ── [TYPES] ───────────────────────────────────────────────
+
+export interface RecommendedPlace extends Place {
+  score:  number;
+  taUrl?: string;
+}
+
+export interface RecommendedRoute {
+  label:         string;
+  description:   string;
+  emoji:         string;
+  places:        RecommendedPlace[];
+  totalDistance: number;
+  totalDuration: number;
+  roads:         RouteResult["roads"];   // 폴리라인용
+  taxiFare:      number;
+  tollFare:      number;
+}
+
+interface KakaoPlaceItem {
+  id: string; place_name: string; address_name: string;
+  x: string; y: string; distance: string;
+}
+
+// ── [UTIL] ────────────────────────────────────────────────
+
+const taUrl = (path: string) =>
+  import.meta.env.DEV
+    ? `/vite-proxy/tripadvisor/v1/${path}`
+    : `${import.meta.env.VITE_BACKEND_URL}/api/tripadvisor/${path}`;
+
+const fetchTaLocationId = async (name: string, lat: number, lng: number): Promise<string | null> => {
+  try {
+    const params = new URLSearchParams({ searchQuery: name, latLong: `${lat},${lng}`, language: "ko", key: TA_API_KEY });
+    const res    = await fetch(`${taUrl("location/search")}?${params}`);
+    if (!res.ok) return null;
+    const json   = await res.json();
+    return json.data?.[0]?.location_id ?? null;
+  } catch { return null; }
+};
+
+const fetchTaDetail = async (id: string): Promise<{ rating: number; reviews: number; webUrl: string } | null> => {
+  try {
+    const params = new URLSearchParams({ language: "ko", key: TA_API_KEY });
+    const res    = await fetch(`${taUrl(`location/${id}/details`)}?${params}`);
+    if (!res.ok) return null;
+    const json   = await res.json();
+    return { rating: parseFloat(json.rating ?? "0"), reviews: parseInt(json.num_reviews ?? "0", 10), webUrl: json.web_url ?? "" };
+  } catch { return null; }
+};
+
+/** 점과 선분(출발↔현위치) 간 수직거리 */
+const pointToSegmentDist = (
+  px: number, py: number,
+  ax: number, ay: number,
+  bx: number, by: number,
+): number => {
+  const dx = bx - ax; const dy = by - ay;
+  if (dx === 0 && dy === 0) return Math.hypot(px - ax, py - ay);
+  const t = Math.max(0, Math.min(1, ((px - ax) * dx + (py - ay) * dy) / (dx * dx + dy * dy)));
+  return Math.hypot(px - ax - t * dx, py - ay - t * dy);
+};
+
+// 최근접 이웃으로 방문 순서 최적화
+const optimizeOrder = (places: RecommendedPlace[], startLat: number, startLng: number): RecommendedPlace[] => {
+  const remaining = [...places];
+  const ordered: RecommendedPlace[] = [];
+  let cur = { lat: startLat, lng: startLng };
+  while (remaining.length > 0) {
+    let minI = 0; let minD = Infinity;
+    remaining.forEach((p, i) => {
+      const d = Math.hypot(p.lat - cur.lat, p.lng - cur.lng);
+      if (d < minD) { minD = d; minI = i; }
+    });
+    const next = remaining.splice(minI, 1)[0];
+    ordered.push(next);
+    cur = next;
+  }
+  return ordered;
+};
+
+// Directions API 호출
+const fetchDirections = async (
+  places: RecommendedPlace[], userLat: number, userLng: number,
+): Promise<{ distance: number; duration: number; roads: RouteResult["roads"]; taxiFare: number; tollFare: number }> => {
+  try {
+    if (places.length === 0) return { distance: 0, duration: 0, roads: [], taxiFare: 0, tollFare: 0 };
+    const dest = places[places.length - 1];
+    const wps  = places.slice(0, -1).map(p => `${p.lng},${p.lat}`).join("|");
+    const params = new URLSearchParams({
+      origin: `${userLng},${userLat}`, destination: `${dest.lng},${dest.lat}`,
+      priority: "RECOMMEND", car_fuel: "GASOLINE", car_hipass: "false",
+      alternatives: "false", road_details: "false",
+      ...(wps ? { waypoints: wps } : {}),
+    });
+    const res = await fetch(`${import.meta.env.VITE_KAKAO_DIRECTIONS_URL}?${params}`, {
+      headers: { Authorization: `KakaoAK ${import.meta.env.VITE_KAKAO_REST_API_KEY}` },
+    });
+    if (!res.ok) return { distance: 0, duration: 0, roads: [], taxiFare: 0, tollFare: 0 };
+    const data: DirectionsResponse = await res.json();
+    const route = data.routes?.[0];
+    if (!route || route.result_code !== 0) return { distance: 0, duration: 0, roads: [], taxiFare: 0, tollFare: 0 };
+    return {
+      distance: route.summary.distance, duration: route.summary.duration,
+      roads: route.sections.flatMap(s => s.roads),
+      taxiFare: route.summary.fare.taxi, tollFare: route.summary.fare.toll,
+    };
+  } catch { return { distance: 0, duration: 0, roads: [], taxiFare: 0, tollFare: 0 }; }
+};
+
+// ── [코스별 선정 로직] ─────────────────────────────────────
+//
+// A코스 — 순수 고평점 TOP5
+//   rating × log(reviews) 점수 내림차순
+//   → 가장 검증된 장소 위주
+//
+// B코스 — 거리 효율 TOP5
+//   현위치 기준 거리가 가깝고 동선 내 이탈이 적은 장소 우선
+//   정렬 기준: distance/500 - ratingScore (작을수록 우선)
+//   → 무리 없이 걸어서 다닐 수 있는 코스
+//
+// C코스 — 카테고리 다양성 TOP5
+//   카테고리별 최고점 1개씩 먼저, 나머지 점수 순으로 채움
+//   → A·B와 최대한 다른 장소 조합
+
+type EnrichedPlace = RecommendedPlace & { _ratingScore: number; _distance: number };
+
+const selectA = (pool: EnrichedPlace[]): RecommendedPlace[] =>
+  [...pool].sort((a, b) => b._ratingScore - a._ratingScore).slice(0, MAX_WP);
+
+const selectB = (pool: EnrichedPlace[]): RecommendedPlace[] =>
+  [...pool].sort((a, b) =>
+    (a._distance / 500 - a._ratingScore) - (b._distance / 500 - b._ratingScore)
+  ).slice(0, MAX_WP);
+
+const selectC = (pool: EnrichedPlace[]): RecommendedPlace[] => {
+  const byScore  = [...pool].sort((a, b) => b._ratingScore - a._ratingScore);
+  const selected: RecommendedPlace[] = [];
+  const usedCats = new Set<Category>();
+  for (const p of byScore) {
+    if (selected.length >= MAX_WP) break;
+    if (!usedCats.has(p.category)) { usedCats.add(p.category); selected.push(p); }
+  }
+  for (const p of byScore) {
+    if (selected.length >= MAX_WP) break;
+    if (!selected.find(s => s.id === p.id)) selected.push(p);
+  }
+  return selected;
+};
+
+const COURSES: { label: string; description: string; emoji: string; select: (pool: EnrichedPlace[]) => RecommendedPlace[] }[] = [
+  { label: "고평점 코스",    description: "Tripadvisor 평점 TOP 5 장소만 방문",       emoji: "⭐", select: selectA },
+  { label: "거리 효율 코스", description: "가깝고 동선 효율이 높은 장소 위주",          emoji: "🗺", select: selectB },
+  { label: "다양성 코스",    description: "카테고리별 1위씩 골고루 방문",               emoji: "🎨", select: selectC },
+];
+
+// ── [HOOK] ────────────────────────────────────────────────
+
+interface UseRecommendedRouteOptions {
+  userLat: number;
+  userLng: number;
+  enabled: boolean;
+}
+
+interface UseRecommendedRouteResult {
+  routes:    RecommendedRoute[];   // 후보 3개
+  isLoading: boolean;
+  error:     string | null;
+  refetch:   () => void;
+}
+
+export const useRecommendedRoute = ({
+  userLat, userLng, enabled,
+}: UseRecommendedRouteOptions): UseRecommendedRouteResult => {
+  const [routes,    setRoutes]    = useState<RecommendedRoute[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [error,     setError]     = useState<string | null>(null);
+  const [fetchKey,  setFetchKey]  = useState<number>(0);
+  const cancelledRef = useRef<boolean>(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (!window.kakao?.maps?.services) { setError("카카오맵 서비스가 준비되지 않았습니다"); return; }
+
+    const cacheKey = `rec_routes_${userLat.toFixed(4)}_${userLng.toFixed(4)}`;
+    const cached   = sessionStorage.getItem(cacheKey);
+    if (cached) {
+      try { setRoutes(JSON.parse(cached)); return; }
+      catch { sessionStorage.removeItem(cacheKey); }
+    }
+
+    cancelledRef.current = false;
+    setIsLoading(true);
+    setError(null);
+    setRoutes([]);
+
+    const ps     = new (window.kakao.maps.services as any).Places();
+    const center = new window.kakao.maps.LatLng(userLat, userLng);
+
+    // ── Step 1: 카카오 카테고리 검색 (병렬)
+    let completed = 0;
+    const rawPlaces: { item: KakaoPlaceItem; category: Category }[] = [];
+    const seenIds  = new Set<string>();
+
+    ALL_KAKAO_CATS.forEach(({ code, category }) => {
+      ps.categorySearch(code, (result: KakaoPlaceItem[], status: string) => {
+        completed++;
+        if (!cancelledRef.current) {
+          if (status === (window.kakao.maps.services as any).Status.OK) {
+            result.forEach(item => {
+              const dist = parseInt(item.distance, 10);
+              if (!seenIds.has(item.id) && dist <= SEARCH_RADIUS) {
+                seenIds.add(item.id);
+                rawPlaces.push({ item, category });
+              }
+            });
+          }
+          if (completed === ALL_KAKAO_CATS.length) {
+            if (rawPlaces.length === 0) { setError("주변에 추천할 장소가 없어요"); setIsLoading(false); return; }
+            buildRoutes(rawPlaces);
+          }
+        }
+      }, { location: center, radius: SEARCH_RADIUS, sort: "distance" });
+    });
+
+    // ── Step 2~4: 평점 보강 → 코스 3개 생성 → Directions 호출
+    const buildRoutes = async (items: { item: KakaoPlaceItem; category: Category }[]) => {
+      // 상위 20개만 Tripadvisor 조회 (API 호출 최소화)
+      const candidates = items.slice(0, 20);
+
+      const idResults = await Promise.allSettled(
+        candidates.map(({ item }) => fetchTaLocationId(item.place_name, parseFloat(item.y), parseFloat(item.x)))
+      );
+      if (cancelledRef.current) return;
+
+      const detailResults = await Promise.allSettled(
+        idResults.map(r => r.status === "fulfilled" && r.value ? fetchTaDetail(r.value) : Promise.resolve(null))
+      );
+      if (cancelledRef.current) return;
+
+      // EnrichedPlace 조립 — 코스별 선정에 필요한 _ratingScore, _distance 포함
+      const enriched: EnrichedPlace[] = candidates.map(({ item, category }, i) => {
+        const detail  = detailResults[i].status === "fulfilled" ? detailResults[i].value : null;
+        const rating  = detail?.rating  ?? 0;
+        const reviews = detail?.reviews ?? 0;
+        const dist    = parseInt(item.distance, 10);
+        const ratingScore = rating > 0
+          ? rating * (CATEGORY_WEIGHT[category] ?? 1) * Math.log10(reviews + 1)
+          : 0;
+        return {
+          id: parseInt(item.id, 10), name: item.place_name, category,
+          rating, reviews, score: ratingScore,
+          district: item.address_name.split(" ").slice(0, 2).join(" "),
+          lat: parseFloat(item.y), lng: parseFloat(item.x), distance: dist,
+          taUrl: detail?.webUrl ?? "",
+          _ratingScore: ratingScore,
+          _distance:    dist,
+        };
+      });
+
+      // 평점 있는 곳 우선, 없으면 전체 사용
+      const pool = enriched.filter(p => p._ratingScore > 0).length >= 3
+        ? enriched.filter(p => p._ratingScore > 0)
+        : enriched;
+
+      // 코스별 장소 선정 → 최근접 이웃 순서 최적화 → Directions 병렬 호출
+      const routeResults = await Promise.allSettled(
+        COURSES.map(async course => {
+          const selected = course.select(pool);
+          if (selected.length === 0) throw new Error("경유지 없음");
+          const ordered  = optimizeOrder(selected, userLat, userLng);
+          const dir      = await fetchDirections(ordered, userLat, userLng);
+          return {
+            label:         course.label,
+            description:   course.description,
+            emoji:         course.emoji,
+            places:        ordered,
+            totalDistance: dir.distance,
+            totalDuration: dir.duration,
+            roads:         dir.roads,
+            taxiFare:      dir.taxiFare,
+            tollFare:      dir.tollFare,
+          } as RecommendedRoute;
+        })
+      );
+      if (cancelledRef.current) return;
+
+      const built = routeResults
+        .filter(r => r.status === "fulfilled")
+        .map(r => (r as PromiseFulfilledResult<RecommendedRoute>).value);
+
+      sessionStorage.setItem(cacheKey, JSON.stringify(built));
+      setRoutes(built);
+      setIsLoading(false);
+    };
+
+    return () => { cancelledRef.current = true; };
+  }, [userLat, userLng, enabled, fetchKey]);
+
+  const refetch = useCallback(() => {
+    const cacheKey = `rec_routes_${userLat.toFixed(4)}_${userLng.toFixed(4)}`;
+    sessionStorage.removeItem(cacheKey);
+    setFetchKey(prev => prev + 1);
+  }, [userLat, userLng]);
+
+  return { routes, isLoading, error, refetch };
+};

--- a/Route_Planning/src/types/type.ts
+++ b/Route_Planning/src/types/type.ts
@@ -1,4 +1,4 @@
-export type Tab      = "nearby" | "route";
+export type Tab = "nearby" | "route";
 export type Category = "카페" | "갤러리" | "공원" | "명소" | "문화" | "거리";
 
 export type PlaceData = {

--- a/Route_Planning/src/types/type_kakao.ts
+++ b/Route_Planning/src/types/type_kakao.ts
@@ -2,6 +2,7 @@ export type KakaoLatLng = { getLat: () => number; getLng: () => number };
 export type KakaoLatLngBounds = { extend: (latlng: KakaoLatLng) => void };
 export type KakaoMapInstance = {
   setCenter: (latlng: KakaoLatLng) => void;
+  setLevel:  (level: number) => void;
   setBounds: (bounds: KakaoLatLngBounds, paddingTop?: number, paddingRight?: number, paddingBottom?: number, paddingLeft?: number) => void;
 };
 export type KakaoOverlay  = { setMap: (map: KakaoMapInstance | null) => void };

--- a/Route_Planning/src/types/type_tripadvisor.ts
+++ b/Route_Planning/src/types/type_tripadvisor.ts
@@ -1,0 +1,226 @@
+// Error Type
+export type Error = {
+    message: string;
+    type: string;
+    code: number;
+}
+
+// 장소 주인 정보
+export type OwnerInfo = {
+        id: number;
+        lang: string;
+        text: string;
+        title: string;
+        author: string;
+        published_date: Date;
+};
+
+// 고객들의 후기
+export type UserReview = {
+    username: string;
+    user_location: {
+        name: string;
+        id: string;
+    };
+    review_count: number;
+    reviewer_badge: string;
+    avatar: {
+        additionalProp: string;
+    }
+}
+
+// 댓글(리뷰)
+export type ReviewData = {
+      id: number;
+      lang: string;
+      location_id: number;
+      published_date: Date;
+      rating: number; // 이게 아마 평점
+      helpful_votes: number;
+      rating_image_url: string;
+      url: string;
+      trip_type: string;
+      travel_date: Date;
+      text: string;
+      title: string;
+      owner_response: OwnerInfo;
+      is_machine_translated: boolean;
+      user: UserReview;
+      subratings: {
+        additionalProp: {
+          name: string;
+          localized_name: string;
+          rating_image_url: string;
+          value: number;
+        }
+      }
+}
+
+// 주소
+export type Address = {
+    street1: string;
+    street2: string;
+    city: string;
+    state: string;
+    country: string
+    postalcode: string;
+    address_string: string;
+}
+
+// 수상 내역(미슐랭과 같은 것들 ㅇㅇ)
+export type Award = {
+    award_type: string;
+    year: number;
+    images: {
+        tiny: string;
+        small: string;
+        large: string;
+    };
+    categories: string[];
+    display_name: string;
+}
+
+// 영업 시간?
+export type Period = {
+    open: {
+        day: number;
+        time: string;
+    };
+
+    close: {
+        day: number;
+        time: string;
+    };
+}
+// ===================================
+// LocationReviews: 해당 장소 리뷰들 관련
+// ===================================
+
+export type LocationReviews_Response = {
+  data: ReviewData[];
+  paging: {
+    next: string;
+    previous: string;
+    results: number;
+    total_results: number;
+    skipped: number;
+  };
+
+  error: Error;
+}
+
+// ===================================================
+// LocationDetails: 해당 장소 상세 정보(위도, 경도, 기타 등등)
+// ===================================================
+
+export type LocationDetails_Response = {
+  location_id: number;
+  name: string;
+  description: string;
+  web_url: string;
+  address_obj: Address;
+//   ancestors: [
+//     {
+//       abbrv: string
+//       level: string
+//       name: string
+//       location_id: 0
+//     }
+//   ], -> 이건 쓸 일 없을 것 같아서 생략 
+  latitude: number;
+  longitude: number;
+  timezone: string;
+  email: string;
+  phone: string;
+  website: string;
+  write_review: string;
+
+  ranking_data: {
+    geo_location_id: number;
+    ranking_string: string;
+    geo_location_name: string;
+    ranking_out_of: number;
+    ranking: number;
+  };
+
+  rating: number;
+  rating_image_url: string;
+  num_reviews: string;
+
+  review_rating_count: {
+    additionalProp: string;
+  };
+
+  subratings: {
+    additionalProp: {
+      name: string;
+      localized_name: string;
+      rating_image_url: string;
+      value: number;
+    }
+  };
+
+  photo_count: number;
+  see_all_photos: string;
+  price_level: string;
+  hours: {
+    periods: Period[];
+    weekday_text: string[];
+  };
+
+  amenities: string[];
+  features: string[];
+  cuisine: [ // 이건 당최 뭔지 모르겠음
+    {
+      name: string;
+      localized_name: string;
+    }
+  ];
+
+  parent_brand: string;
+  brand: string;
+  category: {
+    name: string;
+    localized_name: string;
+  };
+
+  subcategory: [
+    {
+      name: string;
+      localized_name: string;
+    }
+  ];
+
+  groups: [
+    {
+      name: string;
+      localized_name: string;
+      categories: [
+        {
+          name: string;
+          localized_name: string;
+        }
+      ]
+    }
+  ];
+
+  styles: string[];
+
+  neighborhood_info: [ // 아무래도 주변 장소 인듯 
+    {
+      location_id: string;
+      name: string;
+    }
+  ];
+
+  trip_types: [
+    {
+      name: string;
+      localized_name: string;
+      value: string;
+    }
+  ];
+
+  awards: Award[];
+  error: Error;
+}

--- a/Route_Planning/vite.config.ts
+++ b/Route_Planning/vite.config.ts
@@ -1,7 +1,23 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  server: {
+    proxy: {
+      "/vite-proxy/tripadvisor": {
+        target: "https://api.content.tripadvisor.com",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/vite-proxy\/tripadvisor/, ""),
+        configure: (proxy) => {
+          proxy.on("proxyReq", (proxyReq) => {
+            proxyReq.removeHeader("origin");
+            proxyReq.removeHeader("referer");
+            proxyReq.setHeader("Referer", "http://localhost.localdomain");
+            proxyReq.setHeader("Origin", "http://localhost.localdomain");
+          });
+        },
+      },
+    },
+  },
+});


### PR DESCRIPTION

Closes #15 

## 주변 탐색 구현 요약

### 데이터 흐름

1. 사용자 위치 확정 (GPS)
2. 카카오 Places categorySearch (AT4 관광명소 / CT1 문화시설 / CE7 카페) 병렬 호출
3. 반경 내 장소 필터링 + 중복 제거
4. Tripadvisor Location Search → Details 병렬 조회 (장소명 + 좌표로 매칭 → 평점·리뷰수 보강)
5. Place[] 조립 → sessionStorage 캐시 → 화면 표시

### 주요 구성 요소

**`useKakaoNearby` 훅** — 카카오 Places로 반경 내 장소 수집 후 Tripadvisor 평점 보강. 반경(250m / 500m / 1km) 변경 시 자동 재조회, 같은 위치·반경은 캐시 재사용.

**`NearbyMap`** — 지도 위에 장소 마커 오버레이 렌더링. 반경 원(Circle), 선택 장소 강조, 비활성 장소 흐리게 처리.

**`PlaceCard`** — 바텀시트 장소 목록. 카테고리·평점·리뷰수·거리 표시. 카드 탭 시 지도 중심 이동.

---

## 경로 탐색 구현 요약

경로 탐색 패널은 내부적으로 **추천 경로**와 **직접 입력** 두 탭으로 구성됩니다.

### 추천 경로 탭

1. 사용자 위치 확정
2. 카카오 Places (AT4 / CT1 / CE7 / PK6) 병렬 검색 — 2km 반경
3. 상위 20개 Tripadvisor 평점 병렬 보강
4. 3가지 기준으로 각각 최대 5개 선정
  ⭐ 고평점 코스  — rating × log(reviews) 내림차순
  🗺 거리 효율 코스 — 거리/500 - 평점점수 오름차순
  🎨 다양성 코스  — 카테고리별 최고점 1개씩 우선
4. 각 코스 최근접 이웃 알고리즘으로 방문 순서 최적화
5. 카카오 Directions API 병렬 호출 (거리·시간·요금·폴리라인)
6. 후보 카드 3개 표시 → 선택 시 지도에 경로 표시

### 직접 입력 탭

1. 출발지 / 도착지 주소 입력
2. 카카오 Geocoder로 좌표 변환
3. 출발↔도착 중간 지점 기준 카카오 Places 검색
4. 상위 20개 Tripadvisor 평점 병렬 보강
5. 3가지 기준으로 각각 최대 5개 선정
  ⭐ 고평점 코스  — rating × log(reviews) 내림차순
  🗺 동선 효율 코스 — 출발↔도착 선분과의 수직이탈도 최소화 + 평점
  🎨 다양성 코스  — 카테고리별 최고점 1개씩 우선
6. 카카오 Directions API 병렬 호출 (경유지 포함)
7. 후보 카드 3개 표시 → 선택 시 지도에 폴리라인 + 핀 표시

---

## 공통 지도 렌더링

경로 선택 시 `drawOnMap`이 호출되어 교통 혼잡도별 폴리라인(`TRAFFIC_COLOR_MAP`), 출발·경유·도착 핀 오버레이를 지도에 그리고 `setBounds`로 전체 경로가 보이도록 자동 맞춤합니다. `polylineListRef` / `overlayListRef`를 `RouteScreen`에서 단일 ref로 관리해 탭 전환 시 이전 경로가 자동 정리됩니다.

---

## 개선 필요

1. tripadvisor와 kakaomap의 장소명이 서로 달라 평점을 제대로 가져올 수 없음. -> 장소명 통일 필요! (혹은 고유 id 이용)
9. 경로가 너무 뒤죽박죽 형태 -> 좀 더 효율적으로 이동할 수 있는 경로를 생성하게끔 개선 필요!
10. 장소 마커 유형 별로 디자인 구분 해야 할 듯!