### PR TITLE
[backend | 차정민 | add, mod] KPOP 장소 데이터 추가 및 재난문자 TTL 추적기 구현

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,7 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - FASTAPI_URL=http://fastapi-server:8000
+    command: sh -c "npx sequelize-cli db:migrate && node src/app.js"
     depends_on:
       db:
         condition: service_healthy

--- a/express-server/package-lock.json
+++ b/express-server/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "axios": "^1.16.1",
         "cors": "^2.8.6",
+        "csv-parser": "^3.2.1",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "express-rate-limit": "^8.5.2",
@@ -666,7 +667,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -1181,6 +1181,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csv-parser": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/csv-parser/-/csv-parser-3.2.1.tgz",
+      "integrity": "sha512-v8RPMSglouR9od735SnwSxLBbCJqEPSbgm1R5qfr8yIiMUCEFjox56kRZid0SvgHJEkxeIEu3+a9QS3YRh7CuA==",
+      "license": "MIT",
+      "bin": {
+        "csv-parser": "bin/csv-parser"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -1462,7 +1474,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",

--- a/express-server/package.json
+++ b/express-server/package.json
@@ -5,6 +5,7 @@
   "main": "src/app.js",
   "scripts": {
     "start": "node src/app.js",
+    "seed": "node src/scripts/seed-kpop-locations.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -22,6 +23,7 @@
   "dependencies": {
     "axios": "^1.16.1",
     "cors": "^2.8.6",
+    "csv-parser": "^3.2.1",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "express-rate-limit": "^8.5.2",

--- a/express-server/src/app.js
+++ b/express-server/src/app.js
@@ -20,7 +20,7 @@ const REQUIRED_ENV_VARS = [
   'KAKAO_DIRECTIONS_URL',
   'TRIPADVISOR_API_KEY',
   'FASTAPI_URL',
-  'PUBLIC_DATA_API_KEY',
+  'SEOUL_API_KEY',
 ];
 
 const missingVars = REQUIRED_ENV_VARS.filter((key) => !process.env[key]);

--- a/express-server/src/migrations/20260504104132-create-place.js
+++ b/express-server/src/migrations/20260504104132-create-place.js
@@ -25,13 +25,18 @@ module.exports = {
         allowNull: true
       },
       category: {
-        type: Sequelize.ENUM('ACCOMMODATION', 'RESTAURANT', 'CAFE', 'ATTRACTION'),
+        type: Sequelize.ENUM('ACCOMMODATION', 'RESTAURANT', 'CAFE', 'ATTRACTION', 'PLAYGROUND', 'STORE', 'SHOP'),
         allowNull: false
       },
       place_id: {
         type: Sequelize.STRING(100),
+        allowNull: true,
+        unique: true
+      },
+      source: {
+        type: Sequelize.ENUM('TRIPADVISOR', 'CSV'),
         allowNull: false,
-        unique: true 
+        defaultValue: 'TRIPADVISOR'
       },
       coordinates: {
         type: Sequelize.GEOMETRY('POINT', 4326),

--- a/express-server/src/migrations/20260504104136-create-kpop-location.js
+++ b/express-server/src/migrations/20260504104136-create-kpop-location.js
@@ -29,13 +29,22 @@ module.exports = {
       },
       place_id: {
         type: Sequelize.INTEGER,
-        allowNull: false,
+        allowNull: true,
         references: {
-          model: 'Places', // 참조할 테이블
+          model: 'Places',
           key: 'id'
         },
         onUpdate: 'CASCADE',
-        onDelete: 'CASCADE' // 원본 장소가 삭제되면 연결 데이터도 삭제
+        onDelete: 'SET NULL'
+      },
+      media_title: {
+        type: Sequelize.STRING(255),
+        allowNull: true
+      },
+      source_type: {
+        type: Sequelize.ENUM('CSV', 'USER', 'ADMIN'),
+        allowNull: false,
+        defaultValue: 'CSV'
       },
       created_at: {
         allowNull: false,

--- a/express-server/src/migrations/20260504104146-create-disaster-alert.js
+++ b/express-server/src/migrations/20260504104146-create-disaster-alert.js
@@ -9,6 +9,11 @@ module.exports = {
         primaryKey: true,
         type: Sequelize.INTEGER
       },
+      event_id: {
+        type: Sequelize.STRING(16),
+        allowNull: true,
+        unique: true
+      },
       message: {
         type: Sequelize.TEXT,
         allowNull: false

--- a/express-server/src/scripts/seed-kpop-locations.js
+++ b/express-server/src/scripts/seed-kpop-locations.js
@@ -54,7 +54,7 @@ async function seed() {
     const [placeResult] = await db.execute(
       `INSERT INTO Places (category, place_id, coordinates, source, createdAt, updatedAt)
        VALUES (?, NULL, ST_GeomFromText(?, 4326), 'CSV', NOW(), NOW())`,
-      [category, `POINT(${lng} ${lat})`]
+      [category, `POINT(${lat} ${lng})`]
     );
     const placeId = placeResult.insertId;
 

--- a/express-server/src/scripts/seed-kpop-locations.js
+++ b/express-server/src/scripts/seed-kpop-locations.js
@@ -1,0 +1,88 @@
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const csv = require('csv-parser');
+const db = require('../config/db');
+
+const CSV_PATH = path.join(__dirname, '../../data/kpop_locations.csv');
+
+const CATEGORY_MAP = {
+  'cafe': 'CAFE',
+  'restaurant': 'RESTAURANT',
+  'playground': 'PLAYGROUND',
+  'store': 'STORE',
+  'shop': 'SHOP',
+  'stay': 'ACCOMMODATION',
+};
+
+function readCSV() {
+  return new Promise((resolve, reject) => {
+    const rows = [];
+    fs.createReadStream(CSV_PATH)
+      .pipe(csv())
+      .on('data', row => rows.push(row))
+      .on('end', () => resolve(rows))
+      .on('error', reject);
+  });
+}
+
+async function seed() {
+  const [[{ count }]] = await db.execute(
+    "SELECT COUNT(*) as count FROM KpopLocations WHERE source_type = 'CSV'"
+  );
+  if (count > 0) {
+    console.log(`이미 ${count}건의 CSV 데이터가 존재합니다. 시드를 건너뜁니다.`);
+    process.exit(0);
+  }
+
+  const rows = await readCSV();
+  const targets = rows.filter(
+    row => row['미디어타입'] === 'artist' && row['주소'].includes('서울')
+  );
+  console.log(`총 ${targets.length}건 처리 시작`);
+
+  let success = 0;
+  for (const row of targets) {
+    const artistName = row['제목'];
+    const locationName = row['장소명'];
+    const category = CATEGORY_MAP[(row['장소타입'] || '').toLowerCase()] || 'ATTRACTION';
+    const description = row['장소설명'] || null;
+    const lat = parseFloat(row['위도']);
+    const lng = parseFloat(row['경도']);
+
+    // 1. Places INSERT
+    const [placeResult] = await db.execute(
+      `INSERT INTO Places (category, place_id, coordinates, source, createdAt, updatedAt)
+       VALUES (?, NULL, ST_GeomFromText(?, 4326), 'CSV', NOW(), NOW())`,
+      [category, `POINT(${lng} ${lat})`]
+    );
+    const placeId = placeResult.insertId;
+
+    // 2. Artists INSERT IGNORE (name UNIQUE 제약으로 중복 방지)
+    await db.execute(
+      `INSERT IGNORE INTO Artists (name, created_at, updated_at) VALUES (?, NOW(), NOW())`,
+      [artistName]
+    );
+    const [[artist]] = await db.execute(
+      `SELECT id FROM Artists WHERE name = ?`,
+      [artistName]
+    );
+
+    // 3. KpopLocations INSERT
+    await db.execute(
+      `INSERT INTO KpopLocations (artist_id, place_id, location_name, media_title, description, source_type, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, 'CSV', NOW(), NOW())`,
+      [artist.id, placeId, locationName, artistName, description]
+    );
+
+    success++;
+  }
+
+  console.log(`시드 완료: ${success}건 삽입`);
+  process.exit(0);
+}
+
+seed().catch(err => {
+  console.error('시드 실패:', err);
+  process.exit(1);
+});

--- a/fastapi-server/app/main.py
+++ b/fastapi-server/app/main.py
@@ -8,6 +8,7 @@ lifespan에서 scheduler 시작 + event_detector 콜백 등록.
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
+from datetime import datetime
 import logging
 
 from fastapi import FastAPI, Depends
@@ -16,6 +17,7 @@ from sqlalchemy import text
 
 from app.routers import disaster, route, population, cache
 from app.services.scheduler import scheduler
+from app.services.event_detector import DisasterMessage
 from app.database import get_db
 
 logging.basicConfig(level=logging.DEBUG)
@@ -25,20 +27,29 @@ logging.basicConfig(level=logging.DEBUG)
 async def _on_new_disaster_events(events) -> None:
     """
     event_detector가 새 재난/사고를 감지했을 때 호출되는 콜백.
-    DB 세션을 열고 process_and_save() 호출.
+    DB 세션을 열고 process_and_save() 호출 후 TTL 추적 등록.
     """
     from app.routers.disaster import process_and_save
 
     db = next(get_db())
     try:
         for event in events:
-            await process_and_save(
+            if not isinstance(event, DisasterMessage):
+                continue
+            db_id = await process_and_save(
                 event_id=event.event_id,
                 dst_se_nm=event.dst_se_nm,
                 dst_msg=event.dst_msg,
                 danger_level=event.danger_level.value,
                 db=db,
             )
+            if db_id:
+                scheduler.register_disaster_ttl(
+                    db_id=db_id,
+                    dst_msg=event.dst_msg,
+                    area_nm=event.area_nm,
+                    received_at=datetime.now(),
+                )
     finally:
         db.close()
 
@@ -76,6 +87,7 @@ async def health():
         "status": "ok",
         "api_calls": scheduler.api_call_count,
         "seen_events": scheduler.detector.seen_count,
+        "ttl_active": scheduler.ttl_active_count,
     }
 
 

--- a/fastapi-server/app/routers/disaster.py
+++ b/fastapi-server/app/routers/disaster.py
@@ -31,8 +31,9 @@ class AlertRequest(BaseModel):
 
 class SimulateRequest(BaseModel):
     alert_text: str
-    dst_se_nm: str = "기타"    # 재난 유형명 (화재·홍수·가스누출 등)
-    expires_hours: int = 2     # 몇 시간 뒤 만료할지
+    dst_se_nm: str = "기타"
+    expires_hours: int = 72
+    area_nm: str = "명동 관광특구"  # TTL 체크 시 사용할 핫스팟명
 
 
 # ---------------------------------------------------------------------------
@@ -130,7 +131,7 @@ async def process_and_save(
     dst_msg: str,
     danger_level: str,
     db: Session,
-) -> bool:
+) -> int | None:
     """
     EventDetector가 감지한 신규 재난을 Gemini로 분석해 DB에 저장.
 
@@ -139,8 +140,8 @@ async def process_and_save(
     (event_id·dst_se_nm·danger_level 컬럼은 마이그레이션에 없으므로 제외)
 
     Returns:
-        True  — 저장 성공
-        False — 분석 실패 또는 중복 (skip)
+        int  — 저장 성공 시 삽입된 row id
+        None — 분석 실패 또는 중복 (skip)
     """
     # 중복 체크 — message 기준 (event_id 컬럼 없음)
     existing = db.execute(
@@ -148,33 +149,34 @@ async def process_and_save(
         {"msg": dst_msg},
     ).fetchone()
     if existing:
-        return False
+        return None
 
     # Gemini 분석
     try:
         parsed = disaster_service.analyze_alert(dst_msg)
     except Exception as exc:
         logger.warning("[process_and_save] Gemini 분석 실패: %s", exc)
-        return False
+        return None
 
     lat        = float(parsed["lat"])
     lng        = float(parsed["lng"])
     radius_m   = int(parsed["radius"])
     penalty    = disaster_service.calculate_weight_penalty(radius_m)
     received_at = datetime.now()
-    expires_at  = received_at + timedelta(hours=2)
+    expires_at  = received_at + timedelta(hours=72)  # TTL 추적기가 조기 만료 처리
 
     try:
-        db.execute(
+        result = db.execute(
             text("""
                 INSERT INTO DisasterAlerts
-                    (message, coordinates, radius_m, weight_penalty,
+                    (event_id, message, coordinates, radius_m, weight_penalty,
                      received_at, expires_at, created_at, updated_at)
                 VALUES
-                    (:message, ST_GeomFromText(:point, 4326), :radius_m, :penalty,
+                    (:event_id, :message, ST_GeomFromText(:point, 4326), :radius_m, :penalty,
                      :received_at, :expires_at, NOW(), NOW())
             """),
             {
+                "event_id":    event_id,
                 "message":     dst_msg,
                 "point":       f"POINT({lat} {lng})",
                 "radius_m":    radius_m,
@@ -184,12 +186,13 @@ async def process_and_save(
             },
         )
         db.commit()
-        logger.info("[process_and_save] 저장 완료 — lat=%s, lng=%s, radius=%sm", lat, lng, radius_m)
-        return True
+        db_id = result.lastrowid
+        logger.info("[process_and_save] 저장 완료 — id=%d lat=%s lng=%s radius=%sm", db_id, lat, lng, radius_m)
+        return db_id
     except Exception as exc:
         db.rollback()
         logger.error("[process_and_save] DB 저장 실패: %s", exc)
-        return False
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -237,7 +240,7 @@ async def simulate_disaster(request: SimulateRequest, db: Session = Depends(get_
 
     # DB 저장 — 실제 컬럼만 사용
     try:
-        db.execute(
+        result = db.execute(
             text("""
                 INSERT INTO DisasterAlerts
                     (message, coordinates, radius_m, weight_penalty,
@@ -256,12 +259,23 @@ async def simulate_disaster(request: SimulateRequest, db: Session = Depends(get_
             },
         )
         db.commit()
+        db_id = result.lastrowid
     except Exception as exc:
         db.rollback()
         raise HTTPException(status_code=500, detail=f"DB 저장 실패: {exc}")
 
+    # TTL 추적 등록
+    from app.services.scheduler import scheduler
+    scheduler.register_disaster_ttl(
+        db_id=db_id,
+        dst_msg=request.alert_text,
+        area_nm=request.area_nm,
+        received_at=received_at,
+    )
+
     return {
         "status":     "saved",
+        "db_id":      db_id,
         "alert_text": request.alert_text,
         "analysis": {
             "lat":      lat,
@@ -270,4 +284,5 @@ async def simulate_disaster(request: SimulateRequest, db: Session = Depends(get_
             "penalty":  penalty,
         },
         "expires_at": str(expires_at),
+        "ttl_area":   request.area_nm,
     }

--- a/fastapi-server/app/services/scheduler.py
+++ b/fastapi-server/app/services/scheduler.py
@@ -23,10 +23,12 @@ from __future__ import annotations
 import asyncio
 import dataclasses
 import logging
+from datetime import datetime
 
 from app.services.cache import CacheStrategy, cache as default_cache
 from app.services.event_detector import EventDetector
 from app.services.seoul_api import SeoulApiClient, CityData
+from app.services.ttl_tracker import TtlTracker
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +80,8 @@ class Scheduler:
     ) -> None:
         self._cache      = cache or default_cache
         self._detector   = detector or EventDetector()
-        self._api        = api_client or SeoulApiClient()   # ← 추가
+        self._api        = api_client or SeoulApiClient()
+        self._ttl_tracker = TtlTracker(api_client=self._api)
         self._tasks: list[asyncio.Task] = []
         self._sem        = asyncio.Semaphore(_CONCURRENCY)
         self._count_lock = asyncio.Lock()
@@ -100,9 +103,13 @@ class Scheduler:
                 self._loop(self._poll_all_areas, _INTERVAL_CITYDATA),
                 name="scheduler-citydata",
             ),
+            asyncio.create_task(
+                self._ttl_tracker.run(),
+                name="scheduler-ttl",
+            ),
         ]
         logger.info(
-            "[Scheduler] 시작 — 재난·인구·교통 5분, 날씨 1시간, 행사 24시간 주기"
+            "[Scheduler] 시작 — 재난·인구·교통 5분, 날씨 1시간, 행사 24시간 주기 | TTL 추적 활성화"
         )
 
     async def stop(self) -> None:
@@ -233,6 +240,16 @@ class Scheduler:
 
     # ── 공개 속성 ─────────────────────────────────
 
+    def register_disaster_ttl(
+        self,
+        db_id: int,
+        dst_msg: str,
+        area_nm: str,
+        received_at: datetime,
+    ) -> None:
+        """신규 재난을 TTL 추적기에 등록."""
+        self._ttl_tracker.register(db_id, dst_msg, area_nm, received_at)
+
     @property
     def detector(self) -> EventDetector:
         return self._detector
@@ -240,6 +257,10 @@ class Scheduler:
     @property
     def api_call_count(self) -> int:
         return self._api_call_count
+
+    @property
+    def ttl_active_count(self) -> int:
+        return self._ttl_tracker.active_count
 
     @property
     def weather_set_count(self) -> int:

--- a/fastapi-server/app/services/ttl_tracker.py
+++ b/fastapi-server/app/services/ttl_tracker.py
@@ -1,0 +1,194 @@
+"""
+services/ttl_tracker.py
+
+재난문자 TTL 추적기.
+
+재난 감지 직후부터 아래 시퀀스로 '재난이 아직 유효한지' 확인:
+  +1h → +3h → +8h → +12h → +24h → +12h → +8h → +3h → +1h
+  (각 체크 간격, 누적 72시간)
+
+각 체크 시점에 해당 area_nm의 서울 API를 호출해,
+원래 감지된 dst_msg가 응답에서 사라졌으면 DB의 expires_at을 즉시 NOW()로 업데이트.
+72시간 모두 소진 시 자동 만료.
+
+API 호출 실패 시: 보수적으로 '아직 유효'로 처리 (조기 만료 방지).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+
+from sqlalchemy import text
+
+from app.database import SessionLocal
+from app.services.seoul_api import SeoulApiClient
+
+logger = logging.getLogger(__name__)
+
+# 각 체크 간의 간격 (시간 단위) — 누적 72시간
+_TTL_SEQUENCE_HOURS = [1, 3, 8, 12, 24, 12, 8, 3, 1]
+
+# 체커 루프 간격: 1분마다 만료 여부 확인
+_CHECKER_INTERVAL_S = 60
+
+
+def _cumulative_hours(index: int) -> int:
+    """0~index 구간의 누적 시간 반환."""
+    return sum(_TTL_SEQUENCE_HOURS[: index + 1])
+
+
+@dataclass
+class TtlState:
+    db_id: int
+    dst_msg: str        # 재난문자 원문 — 종료 판단 기준
+    area_nm: str        # 서울 API 폴링 대상 핫스팟명
+    received_at: datetime
+    check_index: int = 0
+    next_check_at: datetime = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.next_check_at = self.received_at + timedelta(hours=_cumulative_hours(0))
+
+    def advance(self) -> None:
+        """다음 시퀀스로 이동."""
+        self.check_index += 1
+        self.next_check_at = self.received_at + timedelta(
+            hours=_cumulative_hours(self.check_index)
+        )
+
+    @property
+    def is_exhausted(self) -> bool:
+        return self.check_index >= len(_TTL_SEQUENCE_HOURS)
+
+
+class TtlTracker:
+    """
+    활성 재난의 TTL 시퀀스를 관리.
+
+    사용법 (scheduler.py):
+        tracker = TtlTracker()
+        asyncio.create_task(tracker.run(), name="scheduler-ttl")
+        tracker.register(db_id, dst_msg, area_nm, received_at)
+    """
+
+    def __init__(self, api_client: SeoulApiClient | None = None) -> None:
+        self._api = api_client or SeoulApiClient()
+        self._active: dict[int, TtlState] = {}
+        self._lock = asyncio.Lock()
+
+    # ── 공개 API ─────────────────────────────────
+
+    def register(
+        self,
+        db_id: int,
+        dst_msg: str,
+        area_nm: str,
+        received_at: datetime,
+    ) -> None:
+        """새 재난 등록. 이미 등록된 db_id는 무시."""
+        if db_id in self._active:
+            return
+        state = TtlState(
+            db_id=db_id,
+            dst_msg=dst_msg,
+            area_nm=area_nm,
+            received_at=received_at,
+        )
+        self._active[db_id] = state
+        logger.info(
+            "[TtlTracker] 등록 — id=%d area=%s 다음 체크: %s (+%dh)",
+            db_id,
+            area_nm,
+            state.next_check_at.strftime("%Y-%m-%d %H:%M"),
+            _TTL_SEQUENCE_HOURS[0],
+        )
+
+    async def run(self) -> None:
+        """1분마다 체크 루프 실행 (asyncio.Task로 구동)."""
+        while True:
+            try:
+                await self._tick()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.error("[TtlTracker] 체크 루프 오류: %s", exc)
+            await asyncio.sleep(_CHECKER_INTERVAL_S)
+
+    @property
+    def active_count(self) -> int:
+        return len(self._active)
+
+    # ── 내부 로직 ─────────────────────────────────
+
+    async def _tick(self) -> None:
+        now = datetime.now()
+        async with self._lock:
+            due = [s for s in self._active.values() if now >= s.next_check_at]
+
+        to_expire: list[int] = []
+
+        for state in due:
+            still_active = await self._is_still_active(state)
+
+            if not still_active:
+                logger.info(
+                    "[TtlTracker] 재난 종료 — id=%d (메시지가 API에서 사라짐)",
+                    state.db_id,
+                )
+                to_expire.append(state.db_id)
+                continue
+
+            async with self._lock:
+                state.advance()
+                if state.is_exhausted:
+                    logger.info("[TtlTracker] 72시간 만료 — id=%d", state.db_id)
+                    to_expire.append(state.db_id)
+                else:
+                    logger.info(
+                        "[TtlTracker] 재난 지속 — id=%d 다음 체크: %s (+%dh)",
+                        state.db_id,
+                        state.next_check_at.strftime("%Y-%m-%d %H:%M"),
+                        _TTL_SEQUENCE_HOURS[state.check_index],
+                    )
+
+        if to_expire:
+            await self._expire_many(to_expire)
+            async with self._lock:
+                for db_id in to_expire:
+                    self._active.pop(db_id, None)
+
+    async def _is_still_active(self, state: TtlState) -> bool:
+        """서울 API에서 해당 area의 재난문자 중 state.dst_msg가 있으면 True."""
+        try:
+            citydata = await self._api.fetch_citydata(state.area_nm)
+            if citydata is None or not citydata.disasters:
+                return False
+            return any(d.dst_msg == state.dst_msg for d in citydata.disasters)
+        except Exception as exc:
+            # API 오류 시 조기 만료 방지를 위해 보수적으로 유효 처리
+            logger.warning("[TtlTracker] API 조회 실패 — 유효 유지 (id=%d): %s", state.db_id, exc)
+            return True
+
+    async def _expire_many(self, db_ids: list[int]) -> None:
+        """DisasterAlerts.expires_at을 NOW()로 일괄 업데이트."""
+        db = SessionLocal()
+        try:
+            for db_id in db_ids:
+                db.execute(
+                    text(
+                        "UPDATE DisasterAlerts "
+                        "SET expires_at = NOW(), updated_at = NOW() "
+                        "WHERE id = :id"
+                    ),
+                    {"id": db_id},
+                )
+            db.commit()
+            logger.info("[TtlTracker] DB 만료 처리 완료 — %s", db_ids)
+        except Exception as exc:
+            db.rollback()
+            logger.error("[TtlTracker] DB 만료 처리 실패: %s", exc)
+        finally:
+            db.close()

--- a/fastapi-server/test_seoul_api.py
+++ b/fastapi-server/test_seoul_api.py
@@ -1,0 +1,67 @@
+"""
+서울시 citydata API 응답 확인용 테스트 스크립트.
+
+실행:
+    python test_seoul_api.py                  # 기본 지역 (명동 관광특구)
+    python test_seoul_api.py 경복궁
+    python test_seoul_api.py "홍대 관광특구"
+"""
+
+import sys
+import json
+import urllib.request
+import os
+from pathlib import Path
+
+# .env에서 SEOUL_API_KEY 로드
+env_path = Path(__file__).parent.parent / ".env"
+if env_path.exists():
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        if "=" in line and not line.startswith("#"):
+            k, _, v = line.partition("=")
+            os.environ.setdefault(k.strip(), v.strip())
+
+API_KEY = os.getenv("SEOUL_API_KEY", "")
+if not API_KEY:
+    print("[ERROR] SEOUL_API_KEY가 .env에 없습니다.")
+    sys.exit(1)
+
+AREA = sys.argv[1] if len(sys.argv) > 1 else "명동 관광특구"
+
+
+def fetch(area: str) -> dict:
+    url = f"http://openapi.seoul.go.kr:8088/{API_KEY}/json/citydata/1/1/{urllib.parse.quote(area)}"
+    with urllib.request.urlopen(url, timeout=10) as resp:
+        return json.loads(resp.read())
+
+
+import urllib.parse
+
+print(f"\n=== 서울시 citydata API 테스트 — 지역: {AREA} ===\n")
+
+try:
+    data = fetch(AREA)
+except Exception as e:
+    print(f"[ERROR] API 호출 실패: {e}")
+    sys.exit(1)
+
+citydata = data.get("CITYDATA", {})
+
+# ── LIVE_DST_MESSAGE ──────────────────────────
+print("[ LIVE_DST_MESSAGE ] 실시간 긴급재난문자")
+print("-" * 60)
+messages = citydata.get("LIVE_DST_MESSAGE", [])
+if not messages:
+    print("  (현재 재난문자 없음)")
+else:
+    for i, msg in enumerate(messages, 1):
+        print(f"  [{i}]")
+        print(f"    DST_SE_NM  (재해구분명) : {msg.get('DST_SE_NM', '-')}")
+        print(f"    EMRG_STEP_NM (긴급단계명): {msg.get('EMRG_STEP_NM', '-')}")
+        print(f"    MSG_CN     (메시지내용) : {msg.get('MSG_CN', '-')}")
+        print(f"    CRT_DT     (생성일시)  : {msg.get('CRT_DT', '-')}")
+        print()
+
+# ── 원본 전체 출력 (선택) ────────────────────
+print("\n[ 원본 JSON — LIVE_DST_MESSAGE 전체 ]")
+print(json.dumps(messages, ensure_ascii=False, indent=2))


### PR DESCRIPTION
## 작업 내용

### KPop 장소 DB 마이그레이션 및 시드
- Places 테이블: category ENUM 확장 (PLAYGROUND/STORE/SHOP), place_id nullable, source 컬럼 추가
- KpopLocations 테이블: place_id nullable + onDelete SET NULL, media_title/source_type 컬럼 추가
- 서울 아이돌 방문 장소 979건 CSV 시드 데이터 추가 (`express-server/data/kpop_locations.csv`)
- CSV → DB 시드 스크립트 추가 (`seed-kpop-locations.js`)

### 재난문자 TTL 추적기
- DisasterAlerts 테이블: event_id 컬럼 추가 (서버 재시작 후 중복 감지 복원)
- TtlTracker 구현 및 scheduler.py 연동
- 재난 감지 후 +1h → +3h → +8h → +12h → +24h → +12h → +8h → +3h → +1h 간격으로 서울 API 폴링, 메시지 사라지면 즉시 만료 (최대 72시간)
- docker-compose: express-server 시작 시 db:migrate 자동 실행

### 오류 수정
- 환경변수 오류 수정 (PUBLIC_DATA_API_KEY → SEOUL_API_KEY)